### PR TITLE
Deploy services

### DIFF
--- a/rollup.config.ts
+++ b/rollup.config.ts
@@ -7,7 +7,7 @@ import json from 'rollup-plugin-json'
 
 const pkg = require('./package.json')
 
-const libraryName = 'oasis'
+const libraryName = 'index'
 
 export default {
   input: `src/${libraryName}.ts`,

--- a/src/decoder.ts
+++ b/src/decoder.ts
@@ -8,9 +8,14 @@ export interface RpcDecoder {
 }
 
 export class PlaintextRpcDecoder {
-  async decode(data: Bytes): Promise<RpcRequest> {
+  async decode(data: Bytes, constructor?: boolean): Promise<RpcRequest> {
     if (typeof data === 'string') {
       data = Buffer.from(data, 'hex');
+    }
+
+    // Constructor doesn't use a sighash.
+    if (constructor) {
+      return cbor.decode(data);
     }
 
     return {
@@ -31,6 +36,6 @@ export class ConfidentialRpcDecoder extends PlaintextRpcDecoder {
 }
 
 type RpcRequest = {
-  sighash: Bytes4;
+  sighash?: Bytes4;
   input: any[];
 };

--- a/src/deploy/header.ts
+++ b/src/deploy/header.ts
@@ -1,0 +1,297 @@
+import { Bytes } from '../types';
+const assert = require('assert');
+const bytes = require('../utils/bytes');
+
+export type DeployHeaderOptions = {
+  expiry?: number;
+  confidential?: boolean;
+};
+
+export class DeployHeader {
+  /**
+   * @param {Number} version is the header version number.
+   * @param {Object} is the header body with two fields, expiry (Number)
+   *        and confidential (boolean).
+   */
+  constructor(public version: number, public body: DeployHeaderOptions) {}
+
+  data(): string {
+    let version = DeployHeaderWriter.version(this.version);
+    let body = DeployHeaderWriter.body(this.body);
+
+    assert.equal(body.length % 2, 0);
+
+    let length = DeployHeaderWriter.size(body);
+
+    if (length.substr(2).length > 4) {
+      throw new Error(
+        'Length of the contract deploy header must be no greater than two bytes'
+      );
+    }
+
+    return (
+      '0x' +
+      DeployHeader.prefix() +
+      version.substr(2) +
+      length.substr(2) +
+      body.substr(2)
+    );
+  }
+
+  /**
+   * @param   {Object} headerBody is the header object to encode.
+   * @param   {String} deploycode is a hex string of the current code to which we
+   *          want to prefix the header.
+   * @returns The deploycode with the header prefixed as the encoded wire format, i.e.,
+   *          b'\0sis' || version (2 bytes little endian) || length (2 bytes little endian) || json-header.
+   *          Overrides any header fields that may already exist in the deploycode.
+   */
+  public static deployCode(
+    headerBody: DeployHeaderOptions,
+    deploycode: Bytes
+  ): Bytes {
+    if (typeof deploycode !== 'string') {
+      deploycode = '0x' + deploycode.toString('hex');
+    }
+    DeployHeader.deployCodePreconditions(headerBody, deploycode);
+
+    if (Object.keys(headerBody).length === 0) {
+      // All apis should return buffers not hex strings.
+      return Buffer.from(deploycode.substr(2), 'hex');
+    }
+
+    // Read the existing header, if it exists.
+    let currentHeader = DeployHeaderReader.header(deploycode);
+    // Hex code to create the contract without the serialized deploy header prepended.
+    let initcode;
+    // No header so just make a new one. The initcode is the given deploycode.
+    if (currentHeader === null) {
+      currentHeader = new DeployHeader(DeployHeader.currentVersion(), {});
+      initcode = deploycode;
+    }
+    // Extract the initcode from the deploy code.
+    else {
+      initcode = DeployHeaderReader.initcode(deploycode);
+    }
+    if (headerBody) {
+      Object.assign(currentHeader.body, headerBody);
+    }
+
+    let code = currentHeader.data() + initcode.substr(2);
+
+    // All apis should return buffers not hex strings.
+    return Buffer.from(code.substr(2), 'hex');
+  }
+
+  private static deployCodePreconditions(
+    headerBody: DeployHeaderOptions,
+    deploycode: string
+  ) {
+    if (!deploycode.startsWith('0x')) {
+      throw new Error('Malformed deploycode');
+    }
+    if (!headerBody) {
+      throw new Error('No header given');
+    }
+    if (!DeployHeader.isValidBody(headerBody)) {
+      throw new Error('Malformed deploycode or header');
+    }
+  }
+
+  /**
+   * @returns true iff the keys in the headerBody are part of the valid set.
+   */
+  public static isValidBody(headerBody: DeployHeaderOptions): boolean {
+    let validKeys = ['expiry', 'confidential'];
+
+    let keys = Object.keys(headerBody);
+    for (let k = 0; k < keys.length; k += 1) {
+      if (!validKeys.includes(keys[k])) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  /**
+   * Returns the current version of the header.
+   */
+  public static currentVersion(): number {
+    return 1;
+  }
+
+  /**
+   * Hex representation of b'\0sis'.
+   */
+  public static prefix(): string {
+    return '00736973';
+  }
+}
+
+/**
+ * A collection of utilities for parsing through deploycode including the Oasis contract
+ * deploy header in the form of a hex string.
+ */
+// TODO: change return values to be Bytes (as Buffers).
+export class DeployHeaderReader {
+  /**
+   * @param   {String} deploycode is the transaction data to deploy a contract as a hex string.
+   * @returns the contract deploy header prefixed to the deploycode, otherwise, null.
+   */
+  public static header(deploycode: Bytes): DeployHeader | null {
+    if (typeof deploycode !== 'string') {
+      deploycode = '0x' + deploycode.toString('hex');
+    }
+
+    if (!deploycode.startsWith('0x' + DeployHeader.prefix())) {
+      return null;
+    }
+    let version = DeployHeaderReader.version(deploycode);
+    let body = DeployHeaderReader.body(deploycode);
+
+    if (!DeployHeader.isValidBody(body)) {
+      throw Error(`Invalid body ${JSON.stringify(body)}`);
+    }
+
+    return new DeployHeader(version, body);
+  }
+  /**
+   * @param {String} deploycode is a hex string of the header || initcode.
+   */
+  public static body(deploycode: Bytes): DeployHeaderOptions {
+    if (typeof deploycode !== 'string') {
+      deploycode = '0x' + deploycode.toString('hex');
+    }
+
+    assert.equal(true, deploycode.startsWith('0x' + DeployHeader.prefix()));
+
+    let length = DeployHeaderReader.size(deploycode);
+    let serializedBody = deploycode.substr(
+      DeployHeaderReader.bodyStart(),
+      length * 2
+    );
+
+    return JSON.parse(Buffer.from(serializedBody, 'hex').toString('utf8'));
+  }
+
+  /**
+   * @param {String} deploycode is a hex string of the header || initcode.
+   */
+  public static size(deploycode: Bytes): number {
+    if (typeof deploycode !== 'string') {
+      deploycode = '0x' + deploycode.toString('hex');
+    }
+
+    assert.equal(true, deploycode.startsWith('0x' + DeployHeader.prefix()));
+
+    let length = deploycode.substr(
+      DeployHeaderReader.sizeStart(),
+      DeployHeaderReader.sizeLength()
+    );
+
+    return parseInt('0x' + length, 16);
+  }
+
+  /**
+   * @param {String} deploycode is a hex string of the header || initcode.
+   */
+  public static version(deploycode: Bytes): number {
+    if (typeof deploycode !== 'string') {
+      deploycode = '0x' + deploycode.toString('hex');
+    }
+
+    assert.equal(true, deploycode.startsWith('0x' + DeployHeader.prefix()));
+
+    let version = deploycode.substr(
+      DeployHeaderReader.versionStart(),
+      DeployHeaderReader.versionLength()
+    );
+
+    return parseInt('0x' + version, 16);
+  }
+
+  /**
+   * @param {String} deploycode is a hex string of the header || initcode.
+   */
+  public static initcode(deploycode: Bytes): string {
+    if (typeof deploycode !== 'string') {
+      deploycode = '0x' + deploycode.toString('hex');
+    }
+
+    assert.equal(true, deploycode.startsWith('0x' + DeployHeader.prefix()));
+
+    return (
+      '0x' + deploycode.substr(DeployHeaderReader.initcodeStart(deploycode))
+    );
+  }
+
+  private static initcodeStart(deploycode: Bytes): number {
+    if (typeof deploycode !== 'string') {
+      deploycode = '0x' + deploycode.toString('hex');
+    }
+
+    assert.equal(true, deploycode.startsWith('0x' + DeployHeader.prefix()));
+
+    // Make sure to convert the "length" to nibbles, since it's in units of bytes.
+    return (
+      DeployHeaderReader.bodyStart() + DeployHeaderReader.size(deploycode) * 2
+    );
+  }
+
+  /**
+   * @returns the hex string index of the start section.
+   */
+  private static versionStart(): number {
+    return 2 + DeployHeader.prefix().length;
+  }
+
+  /**
+   * @returns the length of the version in nibbles.
+   */
+  public static versionLength(): number {
+    return 2 * 2;
+  }
+
+  /**
+   * @returns the index of the starting point of the size section.
+   */
+  private static sizeStart(): number {
+    return (
+      DeployHeaderReader.versionStart() + DeployHeaderReader.versionLength()
+    );
+  }
+
+  /**
+   * @returns the length of the header size in nibbles.
+   */
+  private static sizeLength(): number {
+    return 2 * 2;
+  }
+
+  /**
+   * @returns the hex string index of the body section.
+   */
+  private static bodyStart(): number {
+    return DeployHeaderReader.sizeStart() + DeployHeaderReader.sizeLength();
+  }
+}
+
+// TODO: change return values to be Bytes (as Buffers).
+export class DeployHeaderWriter {
+  public static size(body: Bytes): string {
+    if (typeof body !== 'string') {
+      body = '0x' + body.toString('hex');
+    }
+    return bytes.toHex(bytes.parseNumber(body.substr(2).length / 2, 2));
+  }
+
+  public static version(version: number): string {
+    return bytes.toHex(
+      bytes.parseNumber(version, DeployHeaderReader.versionLength() / 2)
+    );
+  }
+
+  public static body(body: DeployHeaderOptions): string {
+    return '0x' + Buffer.from(JSON.stringify(body), 'utf8').toString('hex');
+  }
+}

--- a/src/deploy/index.ts
+++ b/src/deploy/index.ts
@@ -1,0 +1,86 @@
+import Service from '../service';
+import { Idl } from '../idl';
+import { Bytes } from '../types';
+import { Provider, defaultProvider } from '../provider';
+import { DeployHeader, DeployHeaderOptions } from './header';
+import { PlaintextRpcEncoder } from '../encoder';
+
+/**
+ * deploy creates a service on the Oasis cloud.
+ *
+ * @returns a Service object to make rpc requests with.
+ */
+export default async function deploy(options: DeployOptions): Promise<Service> {
+  sanitizeOptions(options);
+
+  let data = await deploycode(options);
+  let request = { data, method: 'oasis_deploy' };
+
+  let prov = provider(options);
+
+  let address = await prov.send(request);
+
+  return new Service(options.idl, address);
+}
+
+/**
+ * Fills in any left out deploy options and converts to the required
+ * types if necessary.
+ */
+function sanitizeOptions(options: DeployOptions) {
+  if (typeof options.bytecode === 'string') {
+    options.bytecode = Buffer.from(options.bytecode.substr(2), 'hex');
+  }
+  options.header = deployHeader(options);
+}
+
+/**
+ * @returns the deploy header options from the given DeployOptions,
+ *          filling in any left out options with the default header.
+ */
+function deployHeader(options: DeployOptions): DeployHeaderOptions {
+  let defaultHeader = { confidential: true };
+  return Object.assign(defaultHeader, options.header);
+}
+
+/**
+ * @returns the deploycode from the given options, i.e.,
+ *          OASIS_HEADER || INITCODE.
+ */
+async function deploycode(options: DeployOptions): Promise<Bytes> {
+  let code = await initcode(options);
+  let header = deployHeader(options);
+  return DeployHeader.deployCode(header, code);
+}
+
+/**
+ * @returns the initcode, i.e., BYTECODE || ABI_ENCODED(args).
+ */
+async function initcode(options: DeployOptions): Promise<Bytes> {
+  let encoder = new PlaintextRpcEncoder();
+  let constructorArgs = options.idl.constructor.inputs;
+  let args = await encoder.encode(
+    { name: 'constructor', inputs: constructorArgs },
+    options.arguments || []
+  );
+  let bytecode = options.bytecode as Buffer;
+  return Buffer.concat([bytecode, args]);
+}
+
+/**
+ * @returns the provider to use for deploying the Service.
+ */
+function provider(options: DeployOptions): Provider {
+  return options.provider || defaultProvider();
+}
+
+/**
+ * DeployOptions specify the arguments for deploying a Service.
+ */
+type DeployOptions = {
+  idl: Idl;
+  bytecode: Bytes;
+  arguments?: Array<any>;
+  header?: DeployHeaderOptions;
+  provider?: Provider;
+};

--- a/src/encoder.ts
+++ b/src/encoder.ts
@@ -16,9 +16,13 @@ export class PlaintextRpcEncoder implements RpcEncoder {
 
     // TODO: input validation. https://github.com/oasislabs/oasis-client/issues/14
 
-    let sighash = Sighash.from(fn);
     let cborEncoded = cbor.encode(args);
 
+    if (fn.name === 'constructor') {
+      return cborEncoded;
+    }
+
+    let sighash = Sighash.from(fn);
     return Buffer.concat([sighash, cborEncoded]);
   }
 }

--- a/src/idl.ts
+++ b/src/idl.ts
@@ -13,6 +13,7 @@
 // }
 export interface Idl {
   [key: string]: any;
+  constructor: RpcConstructor;
 }
 
 type RpcIdent = string;
@@ -25,7 +26,7 @@ type RpcField = {};
 
 enum RpcType {}
 
-type RpcConstructor = {};
+type RpcConstructor = any;
 
 export type RpcFn = {
   name: string;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,5 @@
 import Service from './service';
+import deploy from './deploy';
+import * as utils from './utils';
 
-export { Service };
+export { Service, deploy, utils };

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -1,22 +1,33 @@
+import { Bytes } from '../src/types';
+
 // TODO: https://github.com/oasislabs/oasis-client/issues/12
 
 export interface Provider {
-  send(txData: Buffer): Promise<any>;
+  send(request: Request): Promise<any>;
 }
 
 export class ConfidentialProvider implements Provider {
   constructor(private provider: Provider) {}
 
-  async send(txData: Buffer): Promise<any> {
+  async send(request: Request): Promise<any> {
     // TODO: https://github.com/oasislabs/oasis-client/issues/4.
-    return this.provider.send(txData);
+    return this.provider.send(request);
   }
 }
 
 export class WebsocketProvider {
   constructor(private url: string) {}
 
-  async send(txData: Buffer): Promise<any> {
+  async send(request: Request): Promise<any> {
     // TODO
   }
+}
+
+export type Request = {
+  data: Bytes;
+  method: string;
+};
+
+export function defaultProvider(): Provider {
+  return new WebsocketProvider('wss://web3.oasiscloud.io/ws');
 }

--- a/src/rpc.ts
+++ b/src/rpc.ts
@@ -56,7 +56,8 @@ export class RpcFactory {
     return async (...args: any[]) => {
       let encoder = await this.encoder;
       let txData = await encoder.encode(fn, args);
-      return this.provider.send(txData);
+      let request = { data: txData, method: 'oasis_rpc' };
+      return this.provider.send(request);
     };
   }
 }

--- a/src/service.ts
+++ b/src/service.ts
@@ -9,7 +9,7 @@ import { Provider, WebsocketProvider } from './provider';
  */
 export default class Service {
   public rpc: Rpcs;
-  public address?: Address;
+  public address: Address;
 
   private idl: Idl;
 
@@ -23,7 +23,7 @@ export default class Service {
    * @param address? is the address of the currently deployed
    * @param options? are the optinos configuring the Service client.
    */
-  public constructor(idl: Idl, address?: Address, options?: ServiceOptions) {
+  public constructor(idl: Idl, address: Address, options?: ServiceOptions) {
     options = this.setupOptions(options);
 
     // Attach the rpcs onto the rpc interface so that we can generate dynamic

--- a/src/utils/bytes.ts
+++ b/src/utils/bytes.ts
@@ -1,0 +1,45 @@
+/**
+ * Return a Uint8Array of an ethereum hex-encoded key (EthHex)
+ * @param {String} keystring The EthHex encoding of the value
+ * @returns {Uint8Array} The byte incoding of the value
+ */
+export function parseHex(keystring: string): Uint8Array {
+  if (keystring.indexOf('0x') === 0) {
+    keystring = keystring.substr(2);
+  }
+  let key = keystring.match(/.{1,2}/g);
+
+  if (key === null) {
+    return new Uint8Array();
+  }
+
+  return new Uint8Array(key.map(byte => parseInt(byte, 16)));
+}
+
+/**
+ * Returns an ethereum hex-encoded key of a Uint8Array
+ * @param {Uint8Array} keybytes
+ * @returns {String} The EthHex encoding
+ */
+export function toHex(keybytes: Uint8Array): string {
+  return keybytes.reduce(
+    (str, byte) => str + byte.toString(16).padStart(2, '0'),
+    '0x'
+  );
+}
+
+/**
+ * @returns a Uint8Array representation of number with numBytes.
+ * @param   {Number} number is the number of which we want a byte representation.
+ * @throws  {Error} if the resultant array will be longer than
+ *          numBytes.
+ */
+export function parseNumber(num: number, numBytes: number): Uint8Array {
+  let numberHexStr = num.toString(16);
+  if (numberHexStr.length > numBytes) {
+    throw Error(`cannot parse ${num} into a byte array of length ${numBytes}`);
+  }
+
+  numberHexStr = '0'.repeat(numBytes * 2 - numberHexStr.length) + numberHexStr;
+  return parseHex(numberHexStr);
+}

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,0 +1,4 @@
+import * as bytes from './bytes';
+import { DeployHeaderReader, DeployHeaderWriter } from '../deploy/header';
+
+export { bytes, DeployHeaderReader, DeployHeaderWriter };

--- a/test/deploy-header.spec.ts
+++ b/test/deploy-header.spec.ts
@@ -1,0 +1,108 @@
+import { DeployHeader, DeployHeaderWriter } from '../src/deploy/header';
+
+describe('DeployHeader', () => {
+  describe('deployCode', () => {
+    let failTests = [
+      {
+        description: 'errors when writing a deploy header to empty bytecode',
+        bytecode: '',
+        header: { expiry: 100000, confidential: false },
+        error: 'Malformed deploycode'
+      },
+      {
+        description: 'errors when writing an invalid deploy header',
+        bytecode: '0x1234',
+        header: { invalid: 1234, expiry: 100000, confidential: false },
+        error: 'Malformed deploycode'
+      },
+      {
+        description:
+          'errors when writing to bytecode that already has an invalid header',
+        bytecode: makeExpectedBytecode(
+          { expiry: 100000, confidential: false, badkey: true },
+          '1234'
+        ),
+        header: { expiry: 100000, confidential: false },
+        error:
+          'Invalid body {"expiry":100000,"confidential":false,"badkey":true}'
+      }
+    ];
+
+    failTests.forEach(test => {
+      it(test.description, async function() {
+        expect(() => {
+          '0x' +
+            DeployHeader.deployCode(test.header, test.bytecode).toString('hex');
+        }).toThrowError(test.error);
+      });
+    });
+
+    let successTests = [
+      {
+        description: 'does not change the bytecode if the header is empty',
+        bytecode: '0x1234',
+        header: {},
+        expected: '0x1234'
+      },
+      {
+        description: 'writes a deploy header to non-empty bytecode',
+        bytecode: '0x1234',
+        header: { expiry: 100000, confidential: false },
+        expected: makeExpectedBytecode(
+          { expiry: 100000, confidential: false },
+          '1234'
+        )
+      },
+      {
+        description:
+          'overwrites a deploy header to non-empty bytecode with an existing confidential header',
+        bytecode: makeExpectedBytecode({ confidential: false }, '1234'),
+        header: { confidential: true },
+        expected: makeExpectedBytecode({ confidential: true }, '1234')
+      },
+      {
+        description:
+          'overwrites a deploy header to non-empty bytecode with an existing expiry header',
+        bytecode: makeExpectedBytecode({ expiry: 100000 }, '1234'),
+        header: { expiry: 100001 },
+        expected: makeExpectedBytecode({ expiry: 100001 }, '1234')
+      },
+      {
+        description:
+          'overwrites a deploy header to non-empty bytecode with an existing expiry and confidential header',
+        bytecode: makeExpectedBytecode(
+          { expiry: 100000, confidential: false },
+          '1234'
+        ),
+        header: { expiry: 100001, confidential: true },
+        expected: makeExpectedBytecode(
+          { expiry: 100001, confidential: true },
+          '1234'
+        )
+      }
+    ];
+
+    successTests.forEach(test => {
+      it(test.description, function() {
+        let data = DeployHeader.deployCode(test.header, test.bytecode).toString(
+          'hex'
+        );
+        expect('0x' + data).toBe(test.expected);
+      });
+    });
+  });
+});
+
+function makeExpectedBytecode(headerBody: any, bytecode: any) {
+  let body = DeployHeaderWriter.body(headerBody);
+  let version = DeployHeaderWriter.version(DeployHeader.currentVersion());
+  let size = DeployHeaderWriter.size(body);
+  return (
+    '0x' +
+    DeployHeader.prefix() +
+    version.substr(2) +
+    size.substr(2) +
+    body.substr(2) +
+    bytecode
+  );
+}

--- a/test/deploy.spec.ts
+++ b/test/deploy.spec.ts
@@ -1,0 +1,86 @@
+import { Idl } from '../src/idl';
+import * as oasis from '../src/index';
+import { idl } from './idls/test-contract';
+import { RequestMockProvider } from './utils';
+import { Request } from '../src/provider';
+import { DeployHeaderReader } from '../src/deploy/header';
+import { PlaintextRpcDecoder } from '../src/decoder';
+
+describe('Service deploys', () => {
+  let testCases = [
+    {
+      bytecode: '0x010203',
+      header: undefined,
+      label: 'deploys a service with hex string bytecode'
+    },
+    {
+      bytecode: Buffer.from('0102039999', 'hex'),
+      header: undefined,
+      label: 'deploys a service with buffer bytecode'
+    },
+    {
+      bytecode: Buffer.from('0102039999', 'hex'),
+      header: { confidential: false },
+      label: 'deploys a service without confidentiality'
+    },
+    {
+      bytecode: Buffer.from('0102039999', 'hex'),
+      header: { confidential: true, expiry: 12345 },
+      label: 'deploys a service with expiry'
+    }
+  ];
+
+  testCases.forEach(test => {
+    it(test.label, async () => {
+      // Given an idl, and deploy options.
+      let args = ['constructor-arg'];
+
+      let deployRequestPromise: Promise<Request> = new Promise(
+        async resolve => {
+          // When I deploy.
+          await oasis.deploy({
+            idl,
+            bytecode: test.bytecode,
+            arguments: args,
+            header: test.header,
+            provider: new RequestMockProvider(resolve)
+          });
+        }
+      );
+
+      // Await the request.
+      let deployRequest = await deployRequestPromise;
+
+      // Then it should have made a request to oasis_deploy with the correct deploy code.
+
+      // 1) Check request endpoint:
+      expect(deployRequest.method).toEqual('oasis_deploy');
+
+      // 2) Check the request data:
+      let deployCode: Buffer = deployRequest.data as Buffer;
+
+      // Check header.
+      let header = DeployHeaderReader.header(deployCode);
+      // Should have used the default header since we didn't specify one.
+      let expectedHeader = { version: 1, body: { confidential: true } };
+      if (test.header !== undefined) {
+        expectedHeader.body = test.header!;
+      }
+      expect(JSON.stringify(header)).toEqual(JSON.stringify(expectedHeader));
+
+      // Check initcode (deployCode without the header).
+      let initcode = DeployHeaderReader.initcode(deployCode);
+      // Ensure it's a hex string before comparing.
+      if (typeof test.bytecode !== 'string') {
+        test.bytecode = '0x' + (test.bytecode as Buffer).toString('hex');
+      }
+      expect(initcode.startsWith(test.bytecode)).toEqual(true);
+
+      // Finally check arguments.
+      let encodedArgs = initcode.slice(test.bytecode.length);
+      let decoder = new PlaintextRpcDecoder();
+      let decodedArgs = await decoder.decode(encodedArgs, true);
+      expect(decodedArgs).toEqual(args);
+    });
+  });
+});

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -1,0 +1,16 @@
+import { Provider, Request } from '../src/provider';
+
+/**
+ * RequestMockProvider is a mock provider to pull out the request sent to a provider.
+ */
+export class RequestMockProvider implements Provider {
+  /**
+   * @param requestResolve is a promise's resolve function returning the
+   *        request received by this provider.
+   */
+  constructor(private requestResolve: Function) {}
+
+  async send(request: Request): Promise<any> {
+    this.requestResolve(request);
+  }
+}


### PR DESCRIPTION
Addresses https://github.com/oasislabs/oasis-client/issues/11.

Since we want rpc methods to be directly on the object, the current thinking is that this will look like:

```
let service = await oasis.deploy({
  idl
  arguments,
  bytecode,  
  header: { confidential, expiry },
  provider?,
});

await service.myMethod();
```
so that we can avoid namespace collisions with contracts that have a method `deploy`.

Subject to change.