### PR TITLE
Add event listener api frontend

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
     "@commitlint/cli": "^7.1.2",
     "@commitlint/config-conventional": "^7.1.2",
     "@types/cbor": "^2.0.0",
+    "@types/eventemitter3": "^2.0.2",
     "@types/jest": "^23.3.2",
     "@types/node": "^10.11.0",
     "coveralls": "^3.0.3",
@@ -96,6 +97,7 @@
   "dependencies": {
     "cbor-js": "^0.1.0",
     "deoxysii": "^0.0.1",
+    "eventemitter3": "^3.1.2",
     "js-sha3": "^0.8.0",
     "node-localstorage": "^1.3.1"
   }

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -1,22 +1,34 @@
 import { Bytes } from '../src/types';
+import * as EventEmitter from 'eventemitter3';
 
 // TODO: https://github.com/oasislabs/oasis-client/issues/12
 
 export interface Provider {
-  send(request: Request): Promise<any>;
+  send(request: RpcRequest): Promise<any>;
+  subscribe(request: SubscribeRequest): EventEmitter;
 }
 
-export class WebsocketProvider {
-  constructor(private url: string) {}
+export class WebsocketProvider implements Provider {
+  public constructor(private url: string) {}
 
-  async send(request: Request): Promise<any> {
+  public async send(request: RpcRequest): Promise<any> {
     // TODO
+  }
+
+  public subscribe(request: SubscribeRequest): EventEmitter {
+    // TODO
+    return new EventEmitter();
   }
 }
 
-export type Request = {
+export type RpcRequest = {
   data: Bytes;
   method: string;
+};
+
+export type SubscribeRequest = {
+  event: string;
+  filter?: Object;
 };
 
 export function defaultProvider(): Provider {

--- a/test/unit/deploy.spec.ts
+++ b/test/unit/deploy.spec.ts
@@ -1,7 +1,7 @@
 import { Idl } from '../../src/idl';
 import * as oasis from '../../src/index';
 import { DeployMockProvider } from './utils';
-import { Request } from '../../src/provider';
+import { RpcRequest } from '../../src/provider';
 import { DeployHeaderReader } from '../../src/deploy/header';
 import { PlaintextRpcDecoder } from '../../src/coder/decoder';
 import { idl } from './idls/test-contract';
@@ -36,7 +36,7 @@ describe('Service deploys', () => {
       // Given an idl, and deploy options.
       let args = ['constructor-arg'];
       let service: Service | undefined = undefined;
-      let deployRequestPromise: Promise<Request> = new Promise(
+      let deployRequestPromise: Promise<RpcRequest> = new Promise(
         async resolve => {
           // When I deploy.
           service = await oasis.deploy({

--- a/test/unit/events.spec.ts
+++ b/test/unit/events.spec.ts
@@ -1,0 +1,31 @@
+import Service from '../../src/service';
+import { idl } from './idls/test-contract';
+import { EventEmitterMockProvider } from './utils';
+import * as EventEmitter from 'eventemitter3';
+import { DummyStorage } from '../../src/db';
+
+describe('Events', () => {
+  const address = '0x372FF3aeA1fc69B9C440A5fE0B4c23c38226Da68';
+  it('Adds an event listener', async () => {
+    let remote = new EventEmitter();
+
+    let service = new Service(idl, address, {
+      provider: new EventEmitterMockProvider(remote),
+      db: new DummyStorage()
+    });
+
+    let eventPromise = new Promise(resolve => {
+      service.addEventListener('MyEvent', event => {
+        resolve(event);
+      });
+    });
+
+    let expectedEvent = { MyEvent: 'This is a method' };
+
+    remote.emit('MyEvent', expectedEvent);
+
+    let event = await eventPromise;
+
+    expect(event).toEqual(expectedEvent);
+  });
+});

--- a/test/unit/service.spec.ts
+++ b/test/unit/service.spec.ts
@@ -4,8 +4,8 @@ import {
   PlaintextRpcDecoder,
   ConfidentialRpcDecoder
 } from '../../src/coder/decoder';
-import { Request } from '../../src/provider';
-import { RequestMockProvider, ConfidentialMockProvider } from './utils';
+import { RpcRequest } from '../../src/provider';
+import { RpcRequestMockProvider, ConfidentialMockProvider } from './utils';
 import * as bytes from '../../src/utils/bytes';
 import { idl } from './idls/test-contract';
 import { DummyStorage } from '../../src/db';
@@ -71,10 +71,10 @@ describe('Service', () => {
     let input1 = defType();
     let input2 = bytes.parseHex('1234');
 
-    let txDataPromise: Promise<Request> = new Promise(async resolve => {
+    let txDataPromise: Promise<RpcRequest> = new Promise(async resolve => {
       // Given a service.
       let service = new Service(idl, address, {
-        provider: new RequestMockProvider(resolve),
+        provider: new RpcRequestMockProvider(resolve),
         db: new DummyStorage()
       });
 
@@ -99,7 +99,7 @@ describe('Service', () => {
 
     let serviceKeyPair = nacl.box.keyPair();
 
-    let txDataPromise: Promise<Request> = new Promise(async resolve => {
+    let txDataPromise: Promise<RpcRequest> = new Promise(async resolve => {
       // Given a service.
       let service = new Service(idl, address, {
         provider: new ConfidentialMockProvider(


### PR DESCRIPTION
Punting browser tests for when we actually implement the subscription backend.

Example use [here](https://github.com/oasislabs/oasis-client/pull/28/files#diff-cd253242fd63b864b489aa7056a9f5a9R18).

Addresses https://github.com/oasislabs/oasis-client/issues/27