### PR TITLE
Deploys and request/response gateway interface

### DIFF
--- a/src/confidential/key-store.ts
+++ b/src/confidential/key-store.ts
@@ -79,11 +79,11 @@ export default class KeyStore {
   ): Promise<PublicKey | undefined> {
     // Ensure we are using Uint8Array.
     service = typeof service !== 'string' ? service : bytes.parseHex(service);
-    let pk = await this.gateway.publicKey(service);
-    if (!pk) {
+    let response = await this.gateway.publicKey({ address: service });
+    if (!response.publicKey) {
       return undefined;
     }
-    return pk;
+    return response.publicKey;
   }
 
   /**

--- a/src/deploy/index.ts
+++ b/src/deploy/index.ts
@@ -15,11 +15,10 @@ export default async function deploy(options: DeployOptions): Promise<Service> {
   sanitizeOptions(options);
 
   let data = await deploycode(options);
-  let request = { data };
 
   let gateway = oasisGateway(options);
 
-  let response = await gateway.rpc(request);
+  let response = await gateway.deploy({ data });
 
   if (!response.address) {
     throw new Error(`Invalid gateway response: ${response}`);

--- a/src/oasis-gateway/developer-gateway/api.ts
+++ b/src/oasis-gateway/developer-gateway/api.ts
@@ -41,6 +41,10 @@ export type PublicKeyEvent = {
   signature: string;
 };
 
+export type DeployEvent = {
+  address: string;
+};
+
 /**
  * ErrorEvent is the event that can be polled by the user as a result
  * to a request that failed.

--- a/src/oasis-gateway/index.ts
+++ b/src/oasis-gateway/index.ts
@@ -6,19 +6,40 @@ import * as EventEmitter from 'eventemitter3';
  * OasisGateway is the client's interface used to access services running on Oasis.
  */
 export interface OasisGateway {
-  rpc(request: RpcRequest): Promise<any>;
+  deploy(request: DeployRequest): Promise<DeployResponse>;
+  rpc(request: RpcRequest): Promise<RpcResponse>;
   subscribe(request: SubscribeRequest): EventEmitter;
-  publicKey(address: Address): Promise<PublicKey | undefined>;
+  publicKey(request: PublicKeyRequest): Promise<PublicKeyResponse>;
 }
+
+export type DeployRequest = {
+  data: Bytes;
+};
+
+export type DeployResponse = {
+  address: Address;
+};
+
+export type PublicKeyRequest = {
+  address: Address;
+};
 
 export type RpcRequest = {
   data: Bytes;
   address?: Address;
 };
 
+export type RpcResponse = {
+  output: any;
+};
+
 export type SubscribeRequest = {
   event: string;
   filter?: Object;
+};
+
+export type PublicKeyResponse = {
+  publicKey?: PublicKey;
 };
 
 export function defaultOasisGateway(): OasisGateway {

--- a/src/rpc.ts
+++ b/src/rpc.ts
@@ -100,7 +100,8 @@ export class RpcFactory {
       let coder = await this.coder;
       let txData = await coder.encode(fn, args);
       let request = { data: txData, address: this.address };
-      return this.gateway.rpc(request);
+      let response = await this.gateway.rpc(request);
+      return response.output;
     };
   }
 }

--- a/test/browser/service/index.html
+++ b/test/browser/service/index.html
@@ -74,7 +74,7 @@
           this.requestResolve(request);
         }
         async publicKey(address) {
-          return undefined;
+          return {};
         }
       }
 
@@ -89,7 +89,7 @@
           this.requestResolve(request);
         }
         async publicKey(address) {
-          return keys.peerPublicKey;
+          return { publicKey: keys.peerPublicKey };
         }
       }
 


### PR DESCRIPTION
This PR does two things:

* implements deploys for the `DeveloperGateway` (https://github.com/oasislabs/oasis-client/issues/42)
* cleans up the `OasisGateway` interface definition by requiring all methods to have a request/response interface (instead of accepting individual parameters and returning specific values).