### PR TITLE
WebSocket subscriptions and rpcs to an ethereum/web3 gateway

### DIFF
--- a/src/coder/ethereum.ts
+++ b/src/coder/ethereum.ts
@@ -36,6 +36,11 @@ export class EthereumCoder implements RpcCoder {
     let format = sighashFormat(event, idl);
     return keccak256(format);
   }
+
+  public decodeSubscriptionEvent(log: any, abi: Idl): any {
+    let iface = new Interface(abi as any[]);
+    return iface.parseLog(log).values;
+  }
 }
 
 export function sighashFormat(event: string, idl: Idl): string {

--- a/src/coder/index.ts
+++ b/src/coder/index.ts
@@ -5,7 +5,8 @@ export type RpcCoder = RpcEncoder &
   RpcDecoder &
   RpcFunctions &
   RpcInitcode &
-  RpcSubscribeTopic;
+  RpcSubscribeTopic &
+  RpcSubscriptionEventDecoder;
 
 export interface RpcEncoder {
   encode(fn: RpcFn, args: any[]): Promise<Uint8Array>;
@@ -31,3 +32,7 @@ export type RpcRequest = {
   sighash?: Bytes4;
   input: any[];
 };
+
+interface RpcSubscriptionEventDecoder {
+  decodeSubscriptionEvent(e: any, idl: Idl): any;
+}

--- a/src/coder/oasis.ts
+++ b/src/coder/oasis.ts
@@ -29,6 +29,14 @@ export class OasisCoder implements RpcCoder {
     return keccak256(event);
   }
 
+  public decodeSubscriptionEvent(e: any, idl: Idl): any {
+    return cbor.decode(
+      bytes.parseHex(
+        JSON.parse(Buffer.from(e.data, 'hex').toString('utf-8')).data
+      )
+    );
+  }
+
   public async initcode(
     idl: Idl,
     params: any[],

--- a/src/oasis-gateway/developer-gateway/http.ts
+++ b/src/oasis-gateway/developer-gateway/http.ts
@@ -65,7 +65,7 @@ export class HttpDeveloperGateway implements OasisGateway {
   public async rpc(request: RpcRequest): Promise<RpcResponse> {
     let event = await this.postAndPoll(RpcApi, {
       data: bytes.toHex(request.data),
-      address: bytes.toHex(request.address as Bytes)
+      address: bytes.toHex(request.address!)
     });
     return {
       output: (event as ExecuteServiceEvent).output

--- a/src/oasis-gateway/ethereum-gateway/index.ts
+++ b/src/oasis-gateway/ethereum-gateway/index.ts
@@ -1,0 +1,143 @@
+import * as EventEmitter from 'eventemitter3';
+import * as bytes from '../../utils/bytes';
+import {
+  OasisGateway,
+  DeployRequest,
+  DeployResponse,
+  RpcRequest,
+  RpcResponse,
+  SubscribeRequest,
+  UnsubscribeRequest,
+  PublicKeyRequest,
+  PublicKeyResponse
+} from '../';
+import { JsonRpcWebSocket } from './websocket';
+import { TransactionFactory, Transaction } from './transaction';
+import { Subscriptions } from './subscriptions';
+import keccak256 from '../../utils/keccak256';
+
+export class EthereumGateway implements OasisGateway {
+  /**
+   * Websocket connection to the remote gateway.
+   */
+  private ws: JsonRpcWebSocket;
+
+  /**
+   * Subscription middleware for the websocket connection.
+   */
+  private subscriptions: Subscriptions;
+
+  /**
+   * Builds well formed transactions that are ready for signing.
+   */
+  private transactions: TransactionFactory;
+
+  /**
+   * Wallet for signing transactions.
+   */
+  private wallet: Wallet;
+
+  constructor(url: string, wallet: Wallet) {
+    this.subscriptions = new Subscriptions();
+    this.ws = new JsonRpcWebSocket(url, [this.subscriptions]);
+    this.wallet = wallet;
+    this.transactions = new TransactionFactory(this.wallet.address, this.ws);
+  }
+
+  async deploy(request: DeployRequest): Promise<DeployResponse> {
+    let tx = await this.transactions.create({
+      value: '0x00',
+      data: bytes.toHex(request.data)
+    });
+    let rawTx = await this.wallet.sign(tx);
+    let txHash = (await this.ws.request({
+      method: 'eth_sendRawTransaction',
+      params: [rawTx]
+    })).result;
+    let receipt = (await this.ws.request({
+      method: 'eth_getTransactionReceipt',
+      params: [txHash]
+    })).result;
+
+    return {
+      address: bytes.parseHex(receipt.contractAddress)
+    };
+  }
+
+  async rpc(request: RpcRequest): Promise<RpcResponse> {
+    let tx = await this.transactions.create({
+      value: '0x00',
+      data: bytes.toHex(request.data),
+      to: bytes.toHex(request.address!)
+    });
+    let rawTx = await this.wallet.sign(tx);
+    let txHash = (await this.ws.request({
+      method: 'eth_sendRawTransaction',
+      params: [rawTx]
+    })).result;
+
+    return {
+      output: txHash
+    };
+  }
+
+  subscribe(request: SubscribeRequest): EventEmitter {
+    let events = new EventEmitter();
+    this.ws
+      .request({
+        method: 'eth_subscribe',
+        params: [
+          'logs',
+          {
+            address: bytes.toHex(request.filter!.address),
+            topics: request.filter!.topics.map(t => bytes.toHex(t))
+          }
+        ]
+      })
+      .then(response => {
+        this.subscriptions.add(request.event, response.result, event => {
+          events.emit(request.event, event.params.result);
+        });
+      })
+      .catch(console.error);
+
+    return events;
+  }
+
+  async unsubscribe(request: UnsubscribeRequest) {
+    let id = this.subscriptions.remove(request.event);
+    if (!id) {
+      return;
+    }
+    let response = await this.ws.request({
+      method: 'eth_unsubscribe',
+      params: [id]
+    });
+
+    if (!response.result) {
+      throw new Error(
+        `failed to unsubscribe with request ${request} and response ${response}`
+      );
+    }
+  }
+
+  async publicKey(request: PublicKeyRequest): Promise<PublicKeyResponse> {
+    let response = await this.ws.request({
+      method: 'oasis_getPublicKey',
+      params: [request.address]
+    });
+    // TODO: signature validation. https://github.com/oasislabs/oasis-client/issues/39
+    return {
+      publicKey: response.result.publicKey
+    };
+  }
+
+  public disconnect() {
+    this.ws.disconnect();
+  }
+}
+
+interface Wallet {
+  sign(tx: Transaction): Promise<string>;
+  address: string;
+}

--- a/src/oasis-gateway/ethereum-gateway/subscriptions.ts
+++ b/src/oasis-gateway/ethereum-gateway/subscriptions.ts
@@ -1,0 +1,46 @@
+import { Middleware } from './websocket';
+
+export class Subscriptions implements Middleware {
+  /**
+   * Maps event names to their subscription ids. Used to implement
+   * unsubscribe, as the client frontend knows nothing about the
+   * actual subscription id.
+   */
+  private subscriptionEventIds: Map<string, string> = new Map();
+
+  /**
+   * Maps subscriptionId to the callback to invoke whenever a message
+   * with that id is handled.
+   */
+  private subscriptionCallbacks: Map<string, Function> = new Map();
+
+  handle(message: any): any | undefined {
+    let data = JSON.parse(message.data);
+    if (data.params && data.params.subscription) {
+      let callback = this.subscriptionCallbacks.get(
+        `${data.params.subscription}`
+      );
+      if (callback) {
+        callback(data);
+      }
+      return undefined;
+    }
+    return message;
+  }
+
+  add(event: string, subscriptionId: string, callback) {
+    this.subscriptionEventIds.set(event, subscriptionId);
+    this.subscriptionCallbacks.set(subscriptionId, callback);
+  }
+
+  remove(event: string): string | undefined {
+    let id = this.subscriptionEventIds.get(event);
+    if (!id) {
+      return undefined;
+    }
+    this.subscriptionEventIds.delete(event);
+    this.subscriptionCallbacks.delete(id);
+
+    return id;
+  }
+}

--- a/src/oasis-gateway/ethereum-gateway/transaction.ts
+++ b/src/oasis-gateway/ethereum-gateway/transaction.ts
@@ -1,0 +1,71 @@
+import { JsonRpcWebSocket } from './websocket';
+
+const OASIS_CHAIN_ID = 42261;
+
+export class TransactionFactory {
+  constructor(private address: string, private ws: JsonRpcWebSocket) {}
+
+  async create(tx: UnpreparedTransaction): Promise<Transaction> {
+    let promises: Promise<any>[] = [];
+    if (!tx.gasLimit) {
+      promises.push(this.estimateGas(tx));
+    }
+    if (!tx.nonce) {
+      promises.push(this.nonce());
+    }
+    (await Promise.all(promises)).forEach(r => {
+      tx[r.key] = r.value;
+    });
+
+    if (!tx.gasPrice) {
+      tx.gasPrice = '0x3b9aca00';
+    }
+
+    tx.chainId = OASIS_CHAIN_ID;
+
+    return tx as Transaction;
+  }
+
+  async estimateGas(tx: Object): Promise<any> {
+    return {
+      key: 'gasLimit',
+      value: (await this.ws.request({
+        method: 'eth_estimateGas',
+        params: [tx]
+      })).result
+    };
+  }
+
+  async nonce(): Promise<any> {
+    return {
+      key: 'nonce',
+      value: (await this.ws.request({
+        method: 'eth_getTransactionCount',
+        params: [this.address, 'latest']
+      })).result
+    };
+  }
+}
+
+/**
+ * Transaction that might need fields to be filled in, e.g., via estimateGas.
+ */
+type UnpreparedTransaction = {
+  to?: string;
+  value?: string;
+  data?: string;
+  nonce?: string;
+  gasLimit?: string;
+  gasPrice?: string;
+  chainId?: number;
+};
+
+export type Transaction = {
+  to?: string;
+  value: string;
+  data: string;
+  nonce: string;
+  gasLimit: string;
+  gasPrice: string;
+  chainId: number;
+};

--- a/src/oasis-gateway/ethereum-gateway/websocket.ts
+++ b/src/oasis-gateway/ethereum-gateway/websocket.ts
@@ -1,0 +1,139 @@
+import * as EventEmitter from 'eventemitter3';
+import WebSocket from '../../utils/ws';
+
+export class JsonRpcWebSocket {
+  /**
+   * responses implements a request-response pattern for `send` requests.
+   */
+  private responses: EventEmitter = new EventEmitter();
+
+  /**
+   * Middleware to plug into the websocket connection. Processes ws messages
+   * prior to the default handler defined here.
+   */
+  private middleware: Middleware[];
+
+  /**
+   * JSON rpc request id auto counter.
+   */
+  private requestId: number = 0;
+
+  /**
+   * lifecycle emits events pertaining to the lifecycle of the websocket,
+   * e.g., when it opens or closes.
+   */
+  private lifecycle: EventEmitter = new EventEmitter();
+
+  /**
+   * WebSocket through which all requests are sent.
+   */
+  private websocket: WebSocket;
+
+  constructor(private url: string, middleware: Middleware[]) {
+    this.middleware = middleware;
+    // @ts-ignore
+    this.websocket = new WebSocket(this.url);
+    this.addEventListeners();
+  }
+
+  private addEventListeners() {
+    this.websocket.addEventListener('message', this.message.bind(this));
+    this.websocket.addEventListener('open', this.open.bind(this));
+    this.websocket.addEventListener('error', this.error.bind(this));
+    this.websocket.addEventListener('close', this.close.bind(this));
+  }
+
+  private message(m: any) {
+    m = this.runMiddleware(m);
+    if (!m) {
+      return;
+    }
+    this.handler(m);
+  }
+
+  private runMiddleware(data: any): any | undefined {
+    this.middleware.forEach(m => {
+      data = m.handle(data);
+      if (!data) {
+        return undefined;
+      }
+    });
+    return data;
+  }
+
+  private handler(m: any) {
+    let data = JSON.parse(m.data);
+    this.responses.emit(`${data.id}`, data);
+  }
+
+  private open(event) {
+    this.lifecycle.emit('open');
+  }
+
+  private error(event) {
+    this.lifecycle.emit('error');
+  }
+
+  private close(event) {
+    if (event.code !== CloseEvent.NORMAL) {
+      this.connect();
+      return;
+    }
+    this.lifecycle.emit('close');
+  }
+
+  public connect() {
+    // @ts-ignore
+    this.websocket = new WebSocket(this.url);
+    this.addEventListeners();
+  }
+
+  public disconnect() {
+    this.websocket.close(CloseEvent.NORMAL);
+  }
+
+  public request(request: JsonRpcRequest): Promise<any> {
+    return new Promise(resolve => {
+      // WebSocket is not open, so wait until it's open and try again.
+      if (this.websocket.readyState !== this.websocket.OPEN) {
+        this.lifecycle.once('open', () => {
+          this.request(request)
+            .then(resolve)
+            .catch(console.error);
+        });
+        return;
+      }
+
+      // Websocket is open so proceed.
+      let id = this.nextId();
+      this.responses.once(`${id}`, resolve);
+
+      this.websocket.send(
+        JSON.stringify({
+          id,
+          jsonrpc: '2.0',
+          method: request.method,
+          params: request.params
+        })
+      );
+    });
+  }
+
+  private nextId(): number {
+    this.requestId += 1;
+    return this.requestId - 1;
+  }
+}
+
+enum CloseEvent {
+  NORMAL = 1000
+}
+
+export type JsonRpcRequest = {
+  method: string;
+  params: Object[];
+};
+
+export interface Middleware {
+  handle(message: any): any | undefined;
+}

--- a/src/service.ts
+++ b/src/service.ts
@@ -132,12 +132,9 @@ export default class Service {
 
         // Decode the gateway's response and return it to the listener.
         subscription.addListener(event, e => {
-          e = cbor.decode(
-            bytes.parseHex(
-              JSON.parse(Buffer.from(e.data, 'hex').toString('utf-8')).data
-            )
-          );
-          this.listeners.emit(event, e);
+          let decoded = coder.decodeSubscriptionEvent(e, this.idl);
+
+          this.listeners.emit(event, decoded);
         });
       })
       .catch(err => {

--- a/src/utils/bytes.ts
+++ b/src/utils/bytes.ts
@@ -24,8 +24,13 @@ export function parseHex(keystring: string): Uint8Array {
  * @returns {String} The EthHex encoding
  */
 export function toHex(keybytes: Bytes): string {
-  // Already a hex strig so return.
-  if (typeof keybytes === 'string') return keybytes;
+  // Already a hex string so return.
+  if (typeof keybytes === 'string') {
+    if (!keybytes.startsWith('0x')) {
+      return '0x' + keybytes;
+    }
+    return keybytes;
+  }
   return keybytes.reduce(
     (str, byte) => str + byte.toString(16).padStart(2, '0'),
     '0x'

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -5,6 +5,7 @@ import { Deoxysii, encrypt, decrypt } from '../confidential';
 import { DeployHeaderReader, DeployHeaderWriter } from '../deploy/header';
 import { OasisCoder } from '../coder/oasis';
 import { EthereumCoder } from '../coder/ethereum';
+import { EthereumGateway } from '../oasis-gateway/ethereum-gateway';
 
 export {
   bytes,
@@ -14,6 +15,7 @@ export {
   keccak256,
   OasisCoder,
   EthereumCoder,
+  EthereumGateway,
   Deoxysii,
   DeployHeaderReader,
   DeployHeaderWriter

--- a/src/utils/ws.ts
+++ b/src/utils/ws.ts
@@ -1,0 +1,2 @@
+export default /* tslint:disable */
+(typeof WebSocket !== 'undefined' ? WebSocket : require('ws')) as WebSocket;


### PR DESCRIPTION
Early pr to break this work into smaller reviewable chunks.

I've tested against Devnet and subscriptions + rpcs/deploys seem to work (though I haven't implemented invoke yet).

For a later PR:

- unit tests
- invoke
- passing web3 options  through to the backend gateway
- maybe create a facade for coder + gateway so that we can inject a single object into a service, instead of both the coder and gateway