### PR TITLE
Tsc uses -b flag for project references

### DIFF
--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -16,7 +16,7 @@
     "lint": "tslint  --project tsconfig.json -t codeFrame 'src/**/*.ts' 'test/**/*.ts'",
     "lint:fix": "tslint  --project tsconfig.json -t codeFrame 'src/**/*.ts' 'test/**/*.ts' --fix",
     "prebuild": "rimraf dist",
-    "build": "tsc --module commonjs && rollup -c rollup.config.ts",
+    "build": "tsc -b && rollup -c rollup.config.ts",
     "test": "yarn test:integration && yarn test:browser",
     "test:e2e": "jest test/e2e",
     "test:integration": "jest test/integration",

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -16,7 +16,7 @@
     "lint": "tslint  --project tsconfig.json -t codeFrame 'src/**/*.ts' 'test/**/*.ts'",
     "lint:fix": "tslint  --project tsconfig.json -t codeFrame 'src/**/*.ts' 'test/**/*.ts' --fix",
     "prebuild": "rimraf dist",
-    "build": "tsc --module commonjs && rollup -c rollup.config.ts",
+    "build": "tsc -b && rollup -c rollup.config.ts",
     "test": "jest test/",
     "coverage": "jest test --coverage"
   },

--- a/packages/confidential/package.json
+++ b/packages/confidential/package.json
@@ -16,7 +16,7 @@
     "lint": "tslint  --project tsconfig.json -t codeFrame 'src/**/*.ts' 'test/**/*.ts'",
     "lint:fix": "tslint  --project tsconfig.json -t codeFrame 'src/**/*.ts' 'test/**/*.ts' --fix",
     "prebuild": "rimraf dist",
-    "build": "tsc --module commonjs && rollup -c rollup.config.ts",
+    "build": "tsc -b && rollup -c rollup.config.ts",
     "test": "jest test",
     "coverage": "jest --coverage test"
   },

--- a/packages/developer-gateway-client/package.json
+++ b/packages/developer-gateway-client/package.json
@@ -16,7 +16,7 @@
     "lint": "tslint  --project tsconfig.json -t codeFrame 'src/**/*.ts'",
     "lint:fix": "tslint  --project tsconfig.json -t codeFrame 'src/**/*.ts' --fix",
     "prebuild": "rimraf dist",
-    "build": "tsc --module commonjs && rollup -c rollup.config.ts"
+    "build": "tsc -b && rollup -c rollup.config.ts"
   },
   "jest": {
     "transform": {

--- a/packages/developer-gateway/package.json
+++ b/packages/developer-gateway/package.json
@@ -16,7 +16,7 @@
     "lint": "tslint  --project tsconfig.json -t codeFrame 'src/**/*.ts' 'test/**/*.ts'",
     "lint:fix": "tslint  --project tsconfig.json -t codeFrame 'src/**/*.ts' 'test/**/*.ts' --fix",
     "prebuild": "rimraf dist",
-    "build": "tsc --module commonjs && rollup -c rollup.config.ts",
+    "build": "tsc -b && rollup -c rollup.config.ts",
     "test": "jest test",
     "coverage": "jest test --coverage"
   },

--- a/packages/ethereum/package.json
+++ b/packages/ethereum/package.json
@@ -16,7 +16,7 @@
     "lint": "tslint  --project tsconfig.json -t codeFrame 'src/**/*.ts' 'test/**/*.ts'",
     "lint:fix": "tslint  --project tsconfig.json -t codeFrame 'src/**/*.ts' 'test/**/*.ts' --fix",
     "prebuild": "rimraf dist",
-    "build": "tsc --module commonjs && rollup -c rollup.config.ts",
+    "build": "tsc -b && rollup -c rollup.config.ts",
     "test": "jest",
     "coverage": "jest --coverage test"
   },

--- a/packages/service/package.json
+++ b/packages/service/package.json
@@ -16,7 +16,7 @@
     "lint": "tslint  --project tsconfig.json -t codeFrame 'src/**/*.ts' 'test/**/*.ts'",
     "lint:fix": "tslint  --project tsconfig.json -t codeFrame 'src/**/*.ts' 'test/**/*.ts' --fix",
     "prebuild": "rimraf dist",
-    "build": "tsc --module commonjs && rollup -c rollup.config.ts",
+    "build": "tsc -b && rollup -c rollup.config.ts",
     "test": "jest test",
     "coverage": "jest --coverage test"
   },

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -14,9 +14,9 @@
   "typings": "dist/types/index.d.ts",
   "scripts": {
     "prebuild": "rimraf dist",
-    "lint": "tslint  --project tsconfig.json -t codeFrame 'src/**/*.ts' 'test/**/*.ts'",
+    "lint": "tslint --project tsconfig.json -t codeFrame 'src/**/*.ts' 'test/**/*.ts'",
     "lint:fix": "tslint  --project tsconfig.json -t codeFrame 'src/**/*.ts' 'test/**/*.ts' --fix",
-    "build": "tsc --module commonjs && rollup -c rollup.config.ts"
+    "build": "tsc -b && rollup -c rollup.config.ts"
   },
   "dependencies": {
     "cbor-js": "^0.1.0",


### PR DESCRIPTION
Enables the use of https://www.typescriptlang.org/docs/handbook/project-references.html