### PR TITLE
Adds oasisdocs-rtd as a RO

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,4 @@
 
 # Only the creator of the repo and the oasislabs admins
 # can manage the github settings of this repository
-.github/ @willscott @oasislabs/admin
+.github/ @willscott @armaniferrante @oasislabs/admin

--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -4,6 +4,9 @@ collaborators:
   - username: willscott
     permission: admin
 
+  - username: armaniferrante
+    permission: admin
+
   # Read only access for the oasislabs read the docs user
   - username: oasisdocs-rtd
     permission: pull


### PR DESCRIPTION
* oasisdocs-rtd user can now pull the repo to handle documentation deployment