### PR TITLE
Fix docs badge link

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,9 @@
 [![CircleCI](https://circleci.com/gh/oasislabs/oasis-client.svg?style=svg&circle-token=696729782cc74168d05f5fbb37d49a3e5e6065d3)](https://circleci.com/gh/oasislabs/oasis-client)
 [![Coverage Status](https://coveralls.io/repos/github/oasislabs/oasis-client/badge.svg?branch=master&t=yu91jw)](https://coveralls.io/github/oasislabs/oasis-client?branch=master)
 [![Gitter chat](https://badges.gitter.im/Oasis-official/Lobby.svg)](https://gitter.im/Oasis-official/Lobby?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
-![docs](https://readthedocs.com/projects/oasis-labs-oasis-client/badge/?version=latest)
+[![docs](https://readthedocs.com/projects/oasis-labs-oasis-client/badge/?version=latest)](https://oasis-labs-oasis-client.readthedocs-hosted.com/en/latest/)
+
+See the [documentation](https://readthedocs.com/projects/oasis-labs-oasis-client/badge/?version=latest).
 
 ## Packages
 


### PR DESCRIPTION
Though I think the badge is still showing "unknown" because the docs are private. 