### PR TITLE
ethereum: Minimize browser bundle

### DIFF
--- a/packages/client/rollup/rollup.config.browser.ts
+++ b/packages/client/rollup/rollup.config.browser.ts
@@ -6,7 +6,7 @@ import typescript from 'rollup-plugin-typescript2';
 import json from 'rollup-plugin-json';
 import builtins from 'rollup-plugin-node-builtins';
 import globals from 'rollup-plugin-node-globals';
-import { terser } from "rollup-plugin-terser";
+import { terser } from 'rollup-plugin-terser';
 
 const libraryName = 'index';
 
@@ -15,7 +15,7 @@ export default {
   output: [
     {
       file: 'dist/index.browser.umd.js',
-      name: 'oasis', 
+      name: 'oasis',
       format: 'umd',
       sourcemap: true,
       globals: {
@@ -38,7 +38,7 @@ export default {
     }),
     commonjs({
       namedExports: {
-        '../../node_modules/eventemitter3/index.js': [ 'EventEmitter' ]     
+        '../../node_modules/eventemitter3/index.js': [ 'EventEmitter' ]
       }
     }),
     globals(),
@@ -46,6 +46,6 @@ export default {
     json(),
     typescript({ useTsconfigDeclarationDir: true }),
     sourceMaps(),
-    terser()    
+    terser()
   ],
 };

--- a/packages/ethereum/rollup/rollup.config.browser.ts
+++ b/packages/ethereum/rollup/rollup.config.browser.ts
@@ -6,6 +6,7 @@ import typescript from 'rollup-plugin-typescript2';
 import json from 'rollup-plugin-json';
 import builtins from 'rollup-plugin-node-builtins';
 import globals from 'rollup-plugin-node-globals';
+import { terser } from 'rollup-plugin-terser';
 
 const libraryName = 'index';
 
@@ -42,8 +43,9 @@ export default {
     }),
     globals(),
     builtins(),
-    json(), 
+    json(),
     typescript({ useTsconfigDeclarationDir: true }),
     sourceMaps(),
+    terser()
   ],
 };


### PR DESCRIPTION
Brings the the heavier client browser bundle down to ~420 kb. This includes ethers.js, which is responsible for basically all of the increase from the lighter client's 150 kb. 