### PR TITLE
Async WASM module loading

### DIFF
--- a/packages/service/src/deploy/index.ts
+++ b/packages/service/src/deploy/index.ts
@@ -18,7 +18,7 @@ import { RpcCoder } from '../coder';
  * @returns a Service object to make rpc requests with.
  */
 export default async function deploy(options: DeployOptions): Promise<Service> {
-  sanitizeOptions(options);
+  await sanitizeOptions(options);
 
   let data = await deploycode(options);
 
@@ -40,7 +40,7 @@ export default async function deploy(options: DeployOptions): Promise<Service> {
  * Fills in any left out deploy options and converts to the required
  * types if necessary.
  */
-function sanitizeOptions(options: DeployOptions) {
+async function sanitizeOptions(options: DeployOptions) {
   if (typeof options.bytecode === 'string') {
     options.bytecode = bytes.parseHex(options.bytecode.substr(2));
   }
@@ -48,7 +48,7 @@ function sanitizeOptions(options: DeployOptions) {
 
   // todo: fail gracefully if evm bytecode is given without an idl.
   if (!options.idl) {
-    options.idl = fromWasm(options.bytecode);
+    options.idl = await fromWasm(options.bytecode);
   }
 }
 

--- a/packages/service/src/idl.ts
+++ b/packages/service/src/idl.ts
@@ -19,9 +19,9 @@ export interface Idl {
   constructor: RpcConstructor;
 }
 
-export function fromWasm(bytecode: Uint8Array): Idl {
+export async function fromWasm(bytecode: Uint8Array): Promise<Idl> {
   // @ts-ignore
-  let wasmModule = new WebAssembly.Module(bytecode);
+  let wasmModule = await WebAssembly.compile(bytecode);
   // @ts-ignore
   let sections = WebAssembly.Module.customSections(
     wasmModule,

--- a/packages/service/src/service.ts
+++ b/packages/service/src/service.ts
@@ -88,7 +88,7 @@ export default class Service {
     let wasm = bytes.parseHex(
       DeployHeaderReader.initcode(bytes.toHex(response.code))
     );
-    let idl = fromWasm(wasm);
+    let idl = await fromWasm(wasm);
     return new Service(idl, address, options);
   }
 

--- a/packages/service/test/idl.spec.ts
+++ b/packages/service/test/idl.spec.ts
@@ -1,13 +1,13 @@
 import { fromWasm } from '../src/idl';
 
 describe('Idl', () => {
-  it('Parses the idl from .wasm', () => {
+  it('Parses the idl from .wasm', async () => {
     let path = 'test/wasm/mantle-counter.wasm';
     // Given.
     const bin = new Uint8Array(require('fs').readFileSync(path));
 
     // When.
-    let idl = fromWasm(bin);
+    let idl = await fromWasm(bin);
     // Then.
     let expected = expect(idl).toEqual({
       name: 'MantleCounter',


### PR DESCRIPTION
@sharmaster96 noticed browsers complain about using WebAssembly.Module to synchronously load a wasm module. This switches to async loading.