### PR TITLE
Change local storage localKeys path

### DIFF
--- a/packages/confidential/src/key-store.ts
+++ b/packages/confidential/src/key-store.ts
@@ -16,7 +16,7 @@ export class KeyStore {
   /**
    * LOCAL_KEYS is the db key where the local keypair is stored.
    */
-  private static LOCAL_KEYPAIR_KEY: string = 'me';
+  private static LOCAL_KEYPAIR_KEY: string = '@oasislabs/client/me';
 
   public constructor(db: Db, keyProvider: KeyProvider) {
     this.db = db;


### PR DESCRIPTION
Using `me` conflicts with web3.js. So anyone developing, say, at localhost, will fetch old web3c.js localStorage keys in their browsers.