### PR TITLE
Strong defaults for testing client

### DIFF
--- a/packages/client/package-lock.json
+++ b/packages/client/package-lock.json
@@ -1,0 +1,21 @@
+{
+  "name": "@oasislabs/client",
+  "version": "1.0.0-rc.6",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "find": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/find/-/find-0.3.0.tgz",
+      "integrity": "sha512-iSd+O4OEYV/I36Zl8MdYJO0xD82wH528SaCieTVHhclgiYNe9y+yPKSwK+A7/WsmHL1EZ+pYUJBXWTL5qofksw==",
+      "requires": {
+        "traverse-chain": "~0.1.0"
+      }
+    },
+    "traverse-chain": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/traverse-chain/-/traverse-chain-0.1.0.tgz",
+      "integrity": "sha1-YdvC1Ttp/2CRoSoWj9fUMxB+QPE="
+    }
+  }
+}

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -41,6 +41,7 @@
     "@oasislabs/ethereum": "^1.0.0-rc.5",
     "@oasislabs/gateway": "^1.0.0-rc.5",
     "@oasislabs/service": "^1.0.0-rc.5",
+    "find": "^0.3.0",
     "js-sha3": "^0.8.0"
   },
   "browser": {

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -41,8 +41,10 @@
     "@oasislabs/ethereum": "^1.0.0-rc.5",
     "@oasislabs/gateway": "^1.0.0-rc.5",
     "@oasislabs/service": "^1.0.0-rc.5",
+    "env-paths": "^2.2.0",
     "find": "^0.3.0",
-    "js-sha3": "^0.8.0"
+    "js-sha3": "^0.8.0",
+    "toml": "^3.0.0"
   },
   "browser": {
     "./dist/index.umd.js": "./dist/index.browser.umd.js",

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -1,14 +1,10 @@
 import { keccak256 } from 'js-sha3';
-import Gateway, { RpcOptions, OasisGateway } from '@oasislabs/gateway';
-import { cbor, bytes, Db } from '@oasislabs/common';
+import Gateway from '@oasislabs/gateway';
+import { cbor, bytes } from '@oasislabs/common';
 import {
-  DeployHeaderOptions,
-  Idl,
   OasisCoder,
-  RpcCoder,
   Service,
   deploy,
-  fromWasmSync,
   header,
   setGateway,
   defaultOasisGateway
@@ -19,6 +15,7 @@ import {
   EthereumCoder,
   EthereumWallet as Wallet
 } from '@oasislabs/ethereum';
+import workspace from './workspace';
 
 const oasis = {
   Service,
@@ -39,121 +36,16 @@ const oasis = {
     header,
     keccak256
   },
-  service: new Proxy({} as any, {
-    get(svcCache, serviceName) {
-      const find = require('find');
-      const fs = require('fs');
-
-      /* tslint:disable */
-      if (typeof window !== 'undefined') {
-        throw new Error(
-          '`oasis.project` is not (yet) available in the browser'
-        );
-      }
-      /* tslint:enable */
-
-      if (svcCache._populated !== true) {
-        let projectRoot = svcCache.dir;
-        if (projectRoot === undefined) {
-          const path = require('path');
-
-          projectRoot = require('process').cwd();
-          while (!fs.existsSync(path.join(projectRoot, '.git'))) {
-            let parent = path.dirname(projectRoot);
-            if (parent === projectRoot) {
-              projectRoot = undefined;
-            }
-            projectRoot = parent;
-          }
-        }
-
-        if (projectRoot === undefined) {
-          throw new Error(
-            'Could not determine project root. Please manually set `oasis.service.dir`'
-          );
-        }
-
-        find
-          .fileSync(/target\/service\/.*\.wasm/, projectRoot)
-          .reduce((services, wasmPath) => {
-            let bytecode = fs.readFileSync(wasmPath);
-            let idl = fromWasmSync(bytecode);
-            services[idl.name] = new ServiceDefinition(bytecode, idl);
-            return services;
-          }, svcCache);
-
-        svcCache._populated = true;
-      }
-
-      return svcCache[serviceName];
-    }
-  }),
+  workspace,
   disconnect() {
     try {
       defaultOasisGateway().disconnect();
     } catch (_e) {
       // tslint:disable-line no-empty
+      // `defaultOasisGateway` will throw if there's no default gateway.
+      // Disconnecting from a nonexistent gateway is a no-op.
     }
   }
 };
-
-class ServiceDefinition {
-  public idl: Idl;
-  public bytecode: Uint8Array;
-
-  constructor(bytecode: Uint8Array, idl: Idl) {
-    this.bytecode = bytecode;
-    this.idl = idl;
-  }
-
-  public async deploy(...args: any[]): Promise<any> {
-    let numCtorArgs = this.idl.constructor.inputs.length;
-    let options = args[numCtorArgs];
-    let deployOpts = Object.assign({}, options, {
-      arguments: args.slice(0, numCtorArgs),
-      bytecode: this.bytecode,
-      idl: this.idl,
-      gateway: await this._getGateway()
-    });
-    return deploy(deployOpts);
-  }
-
-  async _getGateway(): Promise<OasisGateway> {
-    let gateway;
-    try {
-      return defaultOasisGateway();
-    } catch (e) {
-      /* tslint:disable */
-      if (typeof window !== 'undefined') {
-        throw e;
-      }
-      /* tslint:enable */
-      const configPath =
-        process.env.OASIS_CONFIG_FILE ||
-        require('path').join(
-          require('env-paths')('oasis', { suffix: '' }).config,
-          'config.toml'
-        );
-      const config = require('toml').parse(
-        await require('util').promisify(require('fs').readFile)(configPath)
-      );
-      const profile = process.env.OASIS_PROFILE || 'default';
-      if (!(profile in config.profiles)) {
-        throw new Error(`No profile named \`${profile}\` in ${configPath}`);
-      }
-      const gatewayConfig = config.profiles[profile];
-      setGateway(
-        gatewayConfig.mnemonic
-          ? new Web3Gateway(
-              gatewayConfig.endpoint,
-              Wallet.fromMnemonic(gatewayConfig.mnemonic)
-            )
-          : new Gateway(gatewayConfig.endpoint)
-      );
-
-      return defaultOasisGateway();
-    }
-  }
-}
 
 export default oasis;

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -97,7 +97,7 @@ const oasis = {
   }
 };
 
-export class ServiceDefinition {
+class ServiceDefinition {
   public idl: Idl;
   public bytecode: Uint8Array;
 

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -1,10 +1,14 @@
 import { keccak256 } from 'js-sha3';
-import Gateway from '@oasislabs/gateway';
-import { cbor, bytes } from '@oasislabs/common';
+import Gateway, { RpcOptions, OasisGateway } from '@oasislabs/gateway';
+import { cbor, bytes, Db } from '@oasislabs/common';
 import {
+  DeployHeaderOptions,
+  Idl,
+  OasisCoder,
+  RpcCoder,
   Service,
   deploy,
-  OasisCoder,
+  fromWasmSync,
   header,
   setGateway
 } from '@oasislabs/service';
@@ -14,6 +18,28 @@ import {
   EthereumCoder,
   EthereumWallet as Wallet
 } from '@oasislabs/ethereum';
+
+let config = {};
+if (typeof process !== 'undefined') {
+  const fs = require('fs');
+  let nextIsConfig = false;
+  let configArgv = '{}';
+  for (let i = 0; i < process.argv.length; i++) {
+    let arg = process.argv[i];
+    if (nextIsConfig) {
+      configArgv = arg;
+      break;
+    }
+    if (arg === '-c' || arg === '--config') {
+      nextIsConfig = true;
+    }
+  }
+  let configOrPath = JSON.parse(configArgv);
+  config =
+    typeof configOrPath === 'object'
+      ? configOrPath
+      : JSON.parse(fs.readFileSync(configOrPath));
+}
 
 const oasis = {
   Service,
@@ -33,7 +59,80 @@ const oasis = {
     EthereumCoder,
     header,
     keccak256
+  },
+  config,
+  service: new Proxy({} as any, {
+    get(svcCache, serviceName) {
+      const find = require('find');
+      const fs = require('fs');
+
+      if (typeof window !== 'undefined') {
+        throw '`oasis.project` is not (yet) available in the browser';
+      }
+
+      if (svcCache._populated !== true) {
+        let projectRoot = svcCache.dir;
+        if (projectRoot === undefined) {
+          const path = require('path');
+
+          projectRoot = require('process').cwd();
+          while (!fs.existsSync(path.join(projectRoot, '.git'))) {
+            let parent = path.dirname(projectRoot);
+            if (parent == projectRoot) {
+              projectRoot = undefined;
+            }
+            projectRoot = parent;
+          }
+        }
+
+        if (projectRoot === undefined) {
+          throw 'Could not determine project root. Please manually set `oasis.project.dir`';
+        }
+
+        find
+          .fileSync(/target\/service\/.*\.wasm/, projectRoot)
+          .reduce((services, wasmPath) => {
+            let bytecode = fs.readFileSync(wasmPath);
+            let idl = fromWasmSync(bytecode);
+            services[idl.name] = new ServiceDefinition(bytecode, idl);
+            return services;
+          }, svcCache);
+
+        svcCache._populated = true;
+      }
+
+      return svcCache[serviceName];
+    }
+  })
+};
+
+export class ServiceDefinition {
+  public idl: Idl;
+  public bytecode: Uint8Array;
+
+  constructor(bytecode: Uint8Array, idl: Idl) {
+    this.bytecode = bytecode;
+    this.idl = idl;
   }
+
+  public async deploy(...args: any[]): Promise<any> {
+    let numCtorArgs = this.idl.constructor.inputs.length;
+    let options = args[numCtorArgs];
+    let deployOpts = Object.assign({}, oasis.config, options, {
+      arguments: args.slice(0, numCtorArgs),
+      bytecode: this.bytecode,
+      idl: this.idl
+    });
+    return deploy(deployOpts);
+  }
+}
+
+export type AbbrevDeployOptions = {
+  header?: DeployHeaderOptions;
+  gateway?: OasisGateway;
+  db?: Db;
+  coder?: RpcCoder;
+  options?: RpcOptions;
 };
 
 export default oasis;

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -44,9 +44,13 @@ const oasis = {
       const find = require('find');
       const fs = require('fs');
 
+      /* tslint:disable */
       if (typeof window !== 'undefined') {
-        throw '`oasis.project` is not (yet) available in the browser';
+        throw new Error(
+          '`oasis.project` is not (yet) available in the browser'
+        );
       }
+      /* tslint:enable */
 
       if (svcCache._populated !== true) {
         let projectRoot = svcCache.dir;
@@ -56,7 +60,7 @@ const oasis = {
           projectRoot = require('process').cwd();
           while (!fs.existsSync(path.join(projectRoot, '.git'))) {
             let parent = path.dirname(projectRoot);
-            if (parent == projectRoot) {
+            if (parent === projectRoot) {
               projectRoot = undefined;
             }
             projectRoot = parent;
@@ -64,7 +68,9 @@ const oasis = {
         }
 
         if (projectRoot === undefined) {
-          throw 'Could not determine project root. Please manually set `oasis.service.dir`';
+          throw new Error(
+            'Could not determine project root. Please manually set `oasis.service.dir`'
+          );
         }
 
         find
@@ -85,7 +91,9 @@ const oasis = {
   disconnect() {
     try {
       defaultOasisGateway().disconnect();
-    } catch (_e) {}
+    } catch (_e) {
+      // tslint:disable-line no-empty
+    }
   }
 };
 
@@ -115,9 +123,11 @@ export class ServiceDefinition {
     try {
       return defaultOasisGateway();
     } catch (e) {
+      /* tslint:disable */
       if (typeof window !== 'undefined') {
         throw e;
       }
+      /* tslint:enable */
       const configPath =
         process.env.OASIS_CONFIG_FILE ||
         require('path').join(
@@ -129,7 +139,7 @@ export class ServiceDefinition {
       );
       const profile = process.env.OASIS_PROFILE || 'default';
       if (!(profile in config.profiles)) {
-        throw `No profile named \`${profile}\` in ${configPath}`;
+        throw new Error(`No profile named \`${profile}\` in ${configPath}`);
       }
       const gatewayConfig = config.profiles[profile];
       setGateway(
@@ -138,7 +148,7 @@ export class ServiceDefinition {
               gatewayConfig.endpoint,
               Wallet.fromMnemonic(gatewayConfig.mnemonic)
             )
-          : (new Gateway(gatewayConfig.endpoint) as OasisGateway)
+          : new Gateway(gatewayConfig.endpoint)
       );
 
       return defaultOasisGateway();

--- a/packages/client/src/workspace.ts
+++ b/packages/client/src/workspace.ts
@@ -1,0 +1,116 @@
+import Gateway, { RpcOptions, OasisGateway } from '@oasislabs/gateway';
+import {
+  Idl,
+  deploy,
+  fromWasmSync,
+  setGateway,
+  defaultOasisGateway
+} from '@oasislabs/service';
+import { Web3Gateway, EthereumWallet as Wallet } from '@oasislabs/ethereum';
+
+let _populatedWorkspace = false;
+
+export default new Proxy({} as any, {
+  get(
+    workspaceCache: { [key: string]: ServiceDefinition },
+    serviceName: string
+  ) {
+    const find = require('find');
+    const fs = require('fs');
+    const process = require('process');
+
+    // tslint:disable-next-line strict-type-predicates
+    if (typeof window !== 'undefined') {
+      throw new Error(
+        '`oasis.workspace` is not (yet) available in the browser'
+      );
+    }
+
+    if (!_populatedWorkspace) {
+      let projectRoot = process.env.OASIS_WORKSPACE;
+      if (projectRoot === undefined) {
+        const path = require('path');
+
+        projectRoot = process.cwd();
+        while (!fs.existsSync(path.join(projectRoot, '.git'))) {
+          let parent = path.dirname(projectRoot);
+          if (parent === projectRoot) {
+            projectRoot = undefined;
+          }
+          projectRoot = parent;
+        }
+      }
+
+      if (projectRoot === undefined) {
+        throw new Error(
+          'Could not find workspace root. Maybe try setting the `OASIS_WORKSPACE` env var?'
+        );
+      }
+
+      find
+        .fileSync(/target\/service\/.*\.wasm/, projectRoot)
+        .reduce((services, wasmPath) => {
+          let bytecode = fs.readFileSync(wasmPath);
+          let idl = fromWasmSync(bytecode);
+          services[idl.name] = new ServiceDefinition(bytecode, idl);
+          return services;
+        }, workspaceCache);
+
+      _populatedWorkspace = true;
+    }
+
+    return workspaceCache[serviceName];
+  }
+});
+
+class ServiceDefinition {
+  constructor(readonly bytecode: Uint8Array, readonly idl: Idl) {}
+
+  public async deploy(...args: any[]): Promise<any> {
+    let numCtorArgs = this.idl.constructor.inputs.length;
+    let options = args[numCtorArgs];
+    let deployOpts = Object.assign({}, options, {
+      arguments: args.slice(0, numCtorArgs),
+      bytecode: this.bytecode,
+      idl: this.idl,
+      gateway: await this._getGateway()
+    });
+    return deploy(deployOpts);
+  }
+
+  private async _getGateway(): Promise<OasisGateway> {
+    let gateway;
+    try {
+      return defaultOasisGateway();
+    } catch (e) {
+      // tslint:disable-next-line strict-type-predicates
+      if (typeof window !== 'undefined') {
+        throw e;
+      }
+      const configPath =
+        process.env.OASIS_CONFIG_FILE ||
+        require('path').join(
+          require('env-paths')('oasis', { suffix: '' }).config,
+          'config.toml'
+        );
+      const config = require('toml').parse(
+        await require('util').promisify(require('fs').readFile)(configPath)
+      );
+      const profile = process.env.OASIS_PROFILE || 'default';
+      if (!(profile in config.profiles)) {
+        throw new Error(`No profile named \`${profile}\` in ${configPath}`);
+      }
+      const gatewayConfig = config.profiles[profile];
+      setGateway(
+        gatewayConfig.mnemonic
+          ? new Web3Gateway(
+              gatewayConfig.endpoint,
+              Wallet.fromMnemonic(gatewayConfig.mnemonic)
+            )
+          : new Gateway(gatewayConfig.endpoint)
+      );
+
+      return defaultOasisGateway();
+    }
+  }
+}

--- a/packages/client/src/workspace.ts
+++ b/packages/client/src/workspace.ts
@@ -43,7 +43,7 @@ export default new Proxy({} as any, {
 
       if (projectRoot === undefined) {
         throw new Error(
-          'Could not find workspace root. Maybe try setting the `OASIS_WORKSPACE` env var?'
+          'Could not find workspace root. Perhaps set the `OASIS_WORKSPACE` env var?'
         );
       }
 
@@ -79,7 +79,6 @@ class ServiceDefinition {
   }
 
   private async _getGateway(): Promise<OasisGateway> {
-    let gateway;
     try {
       return defaultOasisGateway();
     } catch (e) {

--- a/packages/service/src/deploy/index.ts
+++ b/packages/service/src/deploy/index.ts
@@ -46,7 +46,7 @@ async function sanitizeOptions(options: DeployOptions) {
   }
   options.header = deployHeader(options);
 
-  // todo: fail gracefully if evm bytecode is given without an idl.
+  // todo: fail gracefully if bytecode is given without an idl.
   if (!options.idl) {
     options.idl = await fromWasm(options.bytecode);
   }

--- a/packages/service/src/idl.ts
+++ b/packages/service/src/idl.ts
@@ -22,8 +22,14 @@ export interface Idl {
 export class IdlError extends Error {}
 
 export async function fromWasm(bytecode: Uint8Array): Promise<Idl> {
-  // @ts-ignore
-  let wasmModule = await WebAssembly.compile(bytecode);
+  return extractIdl(await WebAssembly.compile(bytecode));
+}
+
+export function fromWasmSync(bytecode: Uint8Array): Idl {
+  return extractIdl(new WebAssembly.Module(bytecode));
+}
+
+function extractIdl(wasmModule: WebAssembly.Module): Idl {
   // @ts-ignore
   let sections = WebAssembly.Module.customSections(
     wasmModule,

--- a/packages/service/src/index.ts
+++ b/packages/service/src/index.ts
@@ -3,7 +3,7 @@ import deploy from './deploy';
 import { header } from './deploy/header';
 import { OasisCoder } from './coder/oasis';
 import { RpcCoder, RpcRequest } from './coder';
-import { Idl, RpcFn } from './idl';
+import { Idl, RpcFn, fromWasmSync, fromWasm } from './idl';
 import {
   OasisGateway,
   SubscribeTopic,
@@ -22,6 +22,8 @@ export {
   SubscribeFilter,
   OasisGateway,
   OasisCoder,
+  fromWasm,
+  fromWasmSync,
   header,
   setGateway
 };

--- a/packages/service/src/index.ts
+++ b/packages/service/src/index.ts
@@ -8,6 +8,7 @@ import {
   OasisGateway,
   SubscribeTopic,
   SubscribeFilter,
+  defaultOasisGateway,
   setGateway
 } from './oasis-gateway';
 
@@ -22,6 +23,7 @@ export {
   SubscribeFilter,
   OasisGateway,
   OasisCoder,
+  defaultOasisGateway,
   fromWasm,
   fromWasmSync,
   header,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "moduleResolution": "node",
     "target": "es5",
-    "module":"es2015",
+    "module": "es2015",
     "lib": ["es2015", "es2016", "es2017", "dom"],
     "strict": true,
     "sourceMap": true,
@@ -11,12 +11,7 @@
     "experimentalDecorators": true,
     "emitDecoratorMetadata": true,
     "noImplicitAny": false,
-    "typeRoots": [
-      "node_modules/@types",
-	  "packages/*/dist/lib"
-    ]
+    "typeRoots": ["node_modules/@types", "packages/*/dist/lib"]
   },
-  "include": [
-    "src"
-  ]
+  "include": ["src"]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2390,6 +2390,11 @@ end-of-stream@^1.0.0, end-of-stream@^1.1.0:
   dependencies:
     once "^1.4.0"
 
+env-paths@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/env-paths/-/env-paths-2.2.0.tgz#cdca557dc009152917d6166e2febe1f039685e43"
+  integrity sha512-6u0VYSCo/OW6IoD5WCLLy9JUGARbamfSavcNXry/eu8aHVFei6CD3Sw+VGX5alea1i9pgPHW0mbu6Xj0uBh7gA==
+
 err-code@^1.0.0:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/err-code/-/err-code-1.1.2.tgz#06e0116d3028f6aef4806849eb0ea6a748ae6960"
@@ -2771,6 +2776,13 @@ find-up@^3.0.0:
   integrity sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==
   dependencies:
     locate-path "^3.0.0"
+
+find@^0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/find/-/find-0.3.0.tgz#4082e8fc8d8320f1a382b5e4f521b9bc50775cb8"
+  integrity sha512-iSd+O4OEYV/I36Zl8MdYJO0xD82wH528SaCieTVHhclgiYNe9y+yPKSwK+A7/WsmHL1EZ+pYUJBXWTL5qofksw==
+  dependencies:
+    traverse-chain "~0.1.0"
 
 flush-write-stream@^1.0.0:
   version "1.1.1"
@@ -7052,6 +7064,11 @@ to-regex@^3.0.1, to-regex@^3.0.2:
     regex-not "^1.0.2"
     safe-regex "^1.1.0"
 
+toml@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/toml/-/toml-3.0.0.tgz#342160f1af1904ec9d204d03a5d61222d762c5ee"
+  integrity sha512-y/mWCZinnvxjTKYhJ+pYxwD0mRLVvOtdS2Awbgxln6iEnt4rk0yBxeSBHkGJcPucRiG0e55mwWp+g/05rsrd6w==
+
 toposort@^2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/toposort/-/toposort-2.0.2.tgz#ae21768175d1559d48bef35420b2f4962f09c330"
@@ -7079,6 +7096,11 @@ tr46@^1.0.1:
   integrity sha1-qLE/1r/SSJUZZ0zN5VujaTtwbQk=
   dependencies:
     punycode "^2.1.0"
+
+traverse-chain@~0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/traverse-chain/-/traverse-chain-0.1.0.tgz#61dbc2d53b69ff6091a12a168fd7d433107e40f1"
+  integrity sha1-YdvC1Ttp/2CRoSoWj9fUMxB+QPE=
 
 trim-newlines@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
```js
import oasis from '@oasislabs/client';

jest.setTimeout(20000);

describe('Quickstart Test', () => {
  it('should deploy non-confidentially', async () => {
    const service = await oasis.service.Quickstart.deploy({
      header: {confidential: false},
    });

    expect(service).toBeTruthy();
  });

  afterAll(() => {
    oasis.disconnect();
  });
});
```

the config is created by the oasis cli and looks like
```toml
[profiles.local]
endpoint = 'http://localhost:8546'
mnemonic = 'range drive remove bleak mule satisfy mandate east lion minimum unfold ready'
```