### PR TITLE
Add build:(node|browser) to common and types

### DIFF
--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -16,6 +16,8 @@
     "lint:fix": "tslint  --project tsconfig.json -t codeFrame 'src/**/*.ts' 'test/**/*.ts' --fix",
     "prebuild": "rimraf dist",
     "build": "tsc -b && rollup -c rollup.config.ts",
+    "build:browser": "npm run-script build",
+    "build:node": "npm run-script build",
     "test": "jest test/",
     "coverage": "jest test --coverage"
   },

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -15,6 +15,8 @@
     "prebuild": "rimraf dist",
     "lint": "tslint --project tsconfig.json -t codeFrame 'src/**/*.ts' 'test/**/*.ts'",
     "lint:fix": "tslint  --project tsconfig.json -t codeFrame 'src/**/*.ts' 'test/**/*.ts' --fix",
-    "build": "tsc -b && rollup -c rollup.config.ts"
+    "build": "tsc -b && rollup -c rollup.config.ts",
+    "build:browser": "npm run-script build",
+    "build:node": "npm run-script build"
   }
 }


### PR DESCRIPTION
This makes it so that someone building on master can use `lerna run build:node` or `build:browser` to quickly build for one of the two targets.