### PR TITLE
gateway session fix empty headers

### DIFF
--- a/packages/gateway/src/session.ts
+++ b/packages/gateway/src/session.ts
@@ -39,6 +39,10 @@ export class HttpSession implements Http {
   ) {
     this.sessionKey = uuid.v4();
     this.headers = headers;
+    this.headers =
+      this.headers && this.headers.headers
+        ? this.headers
+        : { headers: new Map() };
     this.client = client ? client : new AxiosClient();
   }
 


### PR DESCRIPTION
when running tutorial/hello-world/app

FAIL  test/service.spec.ts (7.604s)
  HelloWorld Test
    ✕ deployed (6ms)
    ✕ known greeting
    ✕ insert new greeting in Samoan (1ms)

  ● HelloWorld Test › deployed

    TypeError: Cannot read property 'headers' of undefined

      at HttpSession.<anonymous> (node_modules/@oasislabs/gateway/src/session.ts:55:18)
      at step (node_modules/node_modules/tslib/tslib.es6.js:99:23)
      at Object.next (node_modules/node_modules/tslib/tslib.es6.js:80:53)
      at node_modules/node_modules/tslib/tslib.es6.js:73:71
      at __awaiter (node_modules/node_modules/tslib/tslib.es6.js:69:12)
      at HttpSession.Object.<anonymous>.HttpSession.request (node_modules/@oasislabs/client/dist/index.umd.js:16790:17)
      at HttpGateway.<anonymous> (node_modules/@oasislabs/gateway/src/index.ts:215:41)
      at step (node_modules/node_modules/tslib/tslib.es6.js:99:23)
      at Object.next (node_modules/node_modules/tslib/tslib.es6.js:80:53)


So we should make sure that headers is always an object that can be iterated