### PR TITLE
Remove gateway sanity check request

### DIFF
--- a/packages/ethereum/src/gateway/index.ts
+++ b/packages/ethereum/src/gateway/index.ts
@@ -45,10 +45,6 @@ export class Web3Gateway implements OasisGateway {
     this.ws = new JsonRpcWebSocket(url, [this.subscriptions]);
     this.wallet = wallet;
     this.transactions = new TransactionFactory(this.wallet.address, this.ws);
-
-    this.assertGatewayIsResponsive(url).catch(e => {
-      console.error(`${e}`);
-    });
   }
 
   /**

--- a/packages/gateway/src/index.ts
+++ b/packages/gateway/src/index.ts
@@ -109,10 +109,6 @@ class HttpGateway implements OasisGateway {
       session: this.session
     });
     this.subscriptions = new Map();
-
-    this.assertGatewayIsResponsive(url).catch(e => {
-      console.error(`${e}`);
-    });
   }
 
   /**


### PR DESCRIPTION
These sanity checks were put in to provide feedback if the gateway was misconfigured.

However, the downside is that, if the tutorial tests finish within 3 seconds, they will error and complain about an unresolved promise (this is because we await a timeout for 3 seconds in the sanity check, waiting for a gateway response).

Temporarily removing these sanity checks to resolve that. We should add them back in a better way in the future (for example, we can do them before the very first request is sent through the gateway).