### PR TITLE
Ensure build fails on browser test failure

### DIFF
--- a/packages/client/scripts/test-browser.sh
+++ b/packages/client/scripts/test-browser.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -eo pipefail
+
 # Source common for cleanup on exit.
 source scripts/common.sh
 
@@ -9,6 +11,3 @@ python3 -m http.server 8000 &
 # Run the browser tests.
 node test/browser/service/test.js
 node test/browser/confidential/test.js
-# Do not run the e2e test in CI as it requires
-# an external network.
-#node test/browser/e2e/test.js

--- a/packages/client/test/browser/service/index.html
+++ b/packages/client/test/browser/service/index.html
@@ -71,7 +71,9 @@
           }
           async rpc(request) {
             this.requestResolve(request);
-            return { output: "" }
+            return {
+              output: oasis.utils.bytes.toHex(oasis.utils.cbor.encode({ success: true}))
+            }
           }
           async publicKey(address) {
             return {};
@@ -98,7 +100,7 @@
             return { output: oasis.utils.bytes.parseHex("0x8f4f6346d2dafe2a6a0cb664d4fa17130284e2e123459471e1f0863fb78ad4a45b110d15bcb3dbfe956ebcb14947324c76ec5f571b1a42643cb03bce81aae3f38e68a3") }
           }
           async publicKey(address) {
-            return { publicKey: keys.peerPublicKey };
+            return { publicKey: keys.peerPublicKey.inner };
           }
           async getCode(request) {
             // Just return any bytecode with the deploy header with confidential === true.


### PR DESCRIPTION
Build was passing even though the browser test was failing. This fixes that.

Failing build (as desired): https://circleci.com/gh/oasislabs/oasis.js/872?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-build-link

