### PR TITLE
allow post code for getcode

### DIFF
--- a/packages/gateway/src/api.ts
+++ b/packages/gateway/src/api.ts
@@ -32,7 +32,7 @@ export const RpcApi: DeveloperGatewayApi = {
  */
 export const PublicKeyApi: DeveloperGatewayApi = {
   url: 'v0/api/service/getPublicKey',
-  method: 'GET',
+  method: 'POST',
 };
 
 /**
@@ -40,7 +40,7 @@ export const PublicKeyApi: DeveloperGatewayApi = {
  */
 export const GetCodeApi: DeveloperGatewayApi = {
   url: 'v0/api/service/getCode',
-  method: 'GET',
+  method: 'POST',
 };
 
 /**


### PR DESCRIPTION
axios on the browser does not allow the client to send a payload with a GET request. So, the workaround for this is the send a POST request. Already made the change to developer-gateway to allow a POST request 