### PR TITLE
workspace deploy with error message on constructor arguments

### DIFF
--- a/packages/client/src/workspace.ts
+++ b/packages/client/src/workspace.ts
@@ -124,6 +124,11 @@ export class ServiceDefinition {
         bytecode: this.bytecode,
       };
       args.push(options);
+    } else {
+      throw new WorkspaceError(
+        'The first arguments of the deploy command must be ' +
+          "the service's constructor arguments"
+      );
     }
   }
 }


### PR DESCRIPTION
It is very confusing when we call `oasis deploy` and nothing happens. In this situation, we should just raise an error so that the user knows they are not complying with the API