### PR TITLE
Correctly specify types path for client

### DIFF
--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -18,7 +18,7 @@
   "homepage": "https://github.com/oasislabs/oasis.js#readme",
   "main": "dist/index.umd.js",
   "module": "dist/index.es5.js",
-  "types": "dist/lib/src/index.d.ts",
+  "types": "dist/lib/index.d.ts",
   "license": "Apache-2.0",
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
This should be the last of the changes necessary to export types
```diff
*~/P/p/oasis.js% diff <(find . -path "*dist/lib/src/index.d.ts" | cut -d'/' -f 3 | sort) <(ls packages | sort)
0a1
> client
4a6
> test
```