### PR TITLE
Remove circular export from DeployHeader

### DIFF
--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -5,7 +5,7 @@ import {
   OasisCoder,
   Service,
   deploy,
-  header,
+  DeployHeader,
   setGateway,
   defaultOasisGateway,
   fromWasm,
@@ -34,6 +34,7 @@ export default {
     Web3Gateway,
   },
   utils: {
+    DeployHeader,
     Deoxysii,
     OasisCoder,
     Nonce,
@@ -43,7 +44,6 @@ export default {
     cbor,
     decrypt,
     encrypt,
-    header,
     keccak256,
     idl: {
       fromWasm,

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -54,7 +54,9 @@ export class Balance extends Bytes {
   constructor(repr: string | Uint8Array | bigint | number) {
     let balanceBytes;
     if (typeof repr === 'bigint' || typeof repr === 'number') {
-      balanceBytes = new Uint8Array(new BigInt64Array([BigInt(repr)]).buffer);
+      balanceBytes = new Uint8Array(
+        new BigInt64Array([BigInt(repr), BigInt(0)]).buffer
+      );
     } else {
       balanceBytes = repr;
     }

--- a/packages/service/src/deploy/header.ts
+++ b/packages/service/src/deploy/header.ts
@@ -17,6 +17,14 @@ export class DeployHeader {
    */
   constructor(public version: number, public body: DeployHeaderOptions) {}
 
+  public static parseFromCode(
+    deploycode: Uint8Array | string
+  ): DeployHeader | null {
+    const _deploycode: Uint8Array =
+      typeof deploycode === 'string' ? bytes.parseHex(deploycode) : deploycode;
+    return DeployHeaderReader.header(_deploycode);
+  }
+
   data(): Uint8Array {
     const bodyBytes = DeployHeaderWriter.body(this.body);
     return new Uint8Array(
@@ -281,17 +289,3 @@ export class DeployHeaderWriter {
     return arr;
   }
 }
-
-// Alias.
-function parseFromCode(deploycode: Uint8Array | string): DeployHeader | null {
-  const _deploycode: Uint8Array =
-    typeof deploycode === 'string' ? bytes.parseHex(deploycode) : deploycode;
-
-  return DeployHeaderReader.header(_deploycode);
-}
-
-// Convenience api export.
-export const header = {
-  parseFromCode,
-  deployCode: DeployHeader.deployCode,
-};

--- a/packages/service/src/index.ts
+++ b/packages/service/src/index.ts
@@ -1,7 +1,12 @@
 export { Address, Balance } from '@oasislabs/common';
 export { Service } from './service';
 export { default as deploy } from './deploy';
-export { header } from './deploy/header';
+export {
+  DeployHeader,
+  DeployHeaderError,
+  DeployHeaderReader,
+  DeployHeaderWriter,
+} from './deploy/header';
 export { OasisCoder } from './coder/oasis';
 export { RpcCoder } from './coder';
 export { Idl, RpcFn, fromWasmSync, fromWasm } from './idl';

--- a/packages/service/src/rpc.ts
+++ b/packages/service/src/rpc.ts
@@ -10,7 +10,7 @@ import { OasisGateway, RpcOptions } from './oasis-gateway';
 import { RpcCoder } from './coder';
 import ConfidentialCoder from './coder/confidential';
 import { OasisCoder } from './coder/oasis';
-import { header } from './deploy/header';
+import { DeployHeader } from './deploy/header';
 
 /**
  * Rpcs is a dynamically generated object with rpc methods attached.
@@ -185,7 +185,7 @@ export class RpcFactory {
       throw new ServiceError(address, NO_CODE_ERROR_MSG(address));
     }
 
-    const deployHeader = header.parseFromCode(response.code);
+    const deployHeader = DeployHeader.parseFromCode(response.code);
 
     if (!deployHeader || !deployHeader.body.confidential) {
       return OasisCoder.plaintext();


### PR DESCRIPTION
This fixes
```
error TS2694: Namespace '".../node_modules/@oasislabs/service/dist/lib/src/deploy/header"' has no exported member 'DeployHeader'.

31             deployCode: typeof import("@oasislabs/service/dist/lib/src/deploy/header").DeployHeader.deployCode;

```
when importing `@oasislabs/client` into a (non-RN) typescript project