### PR TITLE
Expose Address in main client

### DIFF
--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@oasislabs/client",
-  "version": "1.0.0-rc.27",
+  "version": "1.0.0-rc.28",
   "description": "Client SDK for interacting with services on Oasis",
   "keywords": [
     "oasis",

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -4,6 +4,7 @@ import { cbor, bytes } from '@oasislabs/common';
 import {
   OasisCoder,
   Service,
+  Address,
   deploy,
   DeployHeader,
   setGateway,
@@ -25,6 +26,7 @@ import Wallet from './wallet';
 
 export default {
   Service,
+  Address,
   deploy,
   Wallet,
   setGateway,

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -5,6 +5,7 @@ import {
   OasisCoder,
   Service,
   Address,
+  Balance,
   deploy,
   DeployHeader,
   setGateway,
@@ -27,6 +28,7 @@ import Wallet from './wallet';
 export default {
   Service,
   Address,
+  Balance,
   deploy,
   Wallet,
   setGateway,

--- a/packages/client/test/e2e/app/service.spec.ts
+++ b/packages/client/test/e2e/app/service.spec.ts
@@ -78,7 +78,7 @@ describe('Counter', () => {
         const currentCounter = logs[k].newCounter;
         const lastCounter = logs[k - 1].newCounter;
 
-        expect(currentCounter - lastCounter).toEqual(1);
+        expect(currentCounter - lastCounter).toBeGreaterThan(0);
       }
     });
 


### PR DESCRIPTION
Connecting to a `Service` with `Service.at` takes `Address` as a parameter. Since this is likely going to be a very common use case, it is a good idea to expose `Address` directly in `@oasislabs/client` to avoid having to import both `@oasislabs/client` and `@oasislabs/service`