### PR TITLE
cbor decode for emitted events ; spellings

### DIFF
--- a/packages/client/README.md
+++ b/packages/client/README.md
@@ -114,7 +114,7 @@ const privateKey = '0x1ad288d73cd2fff6ecf0a5bf167f59e9944559cd70f66cb70170702a0b
 // Wallet for signing and paying for transactions.
 const wallet = new oasis.Wallet(privateKey);
 
-// Etheruem gateway responsible for signing transactions.
+// Ethereum gateway responsible for signing transactions.
 const gateway = new oasis.gateways.Web3Gateway('wss://web3.devnet.oasiscloud.io/ws', wallet);
 
 // Configure the gateway to use.

--- a/packages/common/src/bytes.ts
+++ b/packages/common/src/bytes.ts
@@ -3,7 +3,7 @@
  * @param   keystring is the EthHex encoding of the value
  * @param   littleEndian is true if the keystring should be interpreted as
  *          little endian. Otherwise, defaults to big endian.
- * @returns the byte incoding of the value
+ * @returns the byte encoding of the value
  */
 export function parseHex(keystring: string, littleEndian = false): Uint8Array {
   if (keystring.indexOf('0x') === 0) {
@@ -107,7 +107,7 @@ export function encodeUtf8(input: string): Uint8Array {
 
 /**
  * Converts the given byte array to a number. Cannot parse a number
- * larger than u64, specifically, 2**53-1 (javascripts max number).
+ * larger than u64, specifically, 2**53-1 (javascript's max number).
  */
 export function toNumber(bytes: Uint8Array, le = false): number {
   if (bytes.length > 8) {

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -4,7 +4,7 @@ export { Db, LocalStorage, DummyStorage } from './db';
 export { sleep } from './utils';
 
 /**
- * Lighteweight wrapper for bytes with an easy hex conversion.
+ * Lightweight wrapper for bytes with an easy hex conversion.
  */
 export abstract class Bytes {
   private _bytes: Uint8Array;

--- a/packages/gateway/src/api.ts
+++ b/packages/gateway/src/api.ts
@@ -28,7 +28,7 @@ export const RpcApi: DeveloperGatewayApi = {
 };
 
 /**
- * Retrieives the public key for a service.
+ * Retrieves the public key for a service.
  */
 export const PublicKeyApi: DeveloperGatewayApi = {
   url: 'v0/api/service/getPublicKey',

--- a/packages/service/src/coder/oasis.ts
+++ b/packages/service/src/coder/oasis.ts
@@ -43,7 +43,10 @@ export class OasisCoder implements RpcCoder {
   }
 
   public async decodeSubscriptionEvent(e: any, _idl: Idl): Promise<any> {
-    const event = cbor.decode(bytes.parseHex(e.data));
+    const eventBytes = bytes
+      .parseHex(e.data)
+      .slice(4); // remove size of event
+    const event = cbor.decode(eventBytes);
     return camelCaseKeys(event, { deep: true });
   }
 

--- a/packages/service/test/service.spec.ts
+++ b/packages/service/test/service.spec.ts
@@ -107,7 +107,7 @@ describe('Service', () => {
 
     const request = await txDataPromise;
 
-    // Then the receipient should be able to decrypt it.
+    // Then the recipient should be able to decrypt it.
     const decoder = new ConfidentialGatewayRequestDecoder(keys.privateKey);
     const plaintext = await decoder.decode(request.data);
 

--- a/packages/service/test/utils.ts
+++ b/packages/service/test/utils.ts
@@ -77,7 +77,7 @@ export class RpcRequestMockOasisGateway extends EmptyOasisGateway {
 }
 
 /**
- * Provider that deploys a contract with a fixed adress.
+ * Provider that deploys a contract with a fixed address.
  */
 export class DeployMockOasisGateway extends RpcRequestMockOasisGateway {
   /**

--- a/packages/web3/src/web3/provider.ts
+++ b/packages/web3/src/web3/provider.ts
@@ -9,7 +9,7 @@ import { TransactionFactory, UnpreparedTransaction } from '../transaction';
  * Web3Provider is the brains behind the `Web3` class' implementation, exposing
  * the `send` method, that is responsible for making the JSON RPC request to
  * the Web3 gateway server. It acts as a sort of middle man to ensure requests
- * are handled properly and signed by a wallet when needed. Specficially, it
+ * are handled properly and signed by a wallet when needed. Specifically, it
  *
  * - Transforms rpc requests to their desired behavior, e.g., converts
  *   eth_sendTransaction to eth_sendRawTransaction.

--- a/packages/web3/src/websocket.ts
+++ b/packages/web3/src/websocket.ts
@@ -14,7 +14,7 @@ const ERROR_FORWARD_THRESHOLD = 2;
  * expires.
  *
  * Some RPCs like oasis_invoke are synchronous at the gateway and so this is
- * a bit high. We should bring this down once we remove all synchrous rpcs.
+ * a bit high. We should bring this down once we remove all synchronous rpcs.
  */
 const REQUEST_TIMEOUT_DURATION = 30000;
 
@@ -128,7 +128,7 @@ export class JsonRpcWebSocket implements JsonRpc {
     this.lifecycle.emit('open');
 
     // We were asked to close this websocket while connecting,
-    // so finish the jobn.
+    // so finish the job.
     if (this.closeOnOpen) {
       this.websocket.close(CloseEvent.NORMAL);
       return;


### PR DESCRIPTION
This PR:

- Fixes a bug in `packages/service/src/coder/oasis.ts` when decoding a subscription event.
- Fixes some minor spelling mistakes