### PR TITLE
Remove unused deploy steps from CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -64,60 +64,10 @@ jobs:
       - run: pushd packages/client/test/e2e && oasis build && popd
       - run: oasis-chain > /tmp/oasis-chain.log & yarn test:e2e
 
-  deploy-staging:
-    docker:
-      - image: circleci/python:2.7-jessie
-    steps:
-      - run:
-          name: Install awscli
-          command: sudo pip install awscli
-      - run:
-          # CircleCI's AWS Credentials are allowed to assume a role that has S3
-          # access in the staging account.
-          name: Create an ~/.aws/config file to assume the staging role for aws.
-          command: mkdir -p ~/.aws && printf "[profile staging]\nrole_arn = ${AWS_STAGING_ROLE_ARN}\ncredential_source = Environment\n" > ~/.aws/config
-      - attach_workspace:
-          at: oasis-client
-      - run:
-          name: Deploy to S3
-          command: aws s3 sync --profile staging oasis-client/output/ s3://web3cjs-staging/oasis-client-latest/ --delete
-
-  deploy-release:
-    docker:
-      - image: circleci/python:2.7-jessie
-    steps:
-      - run:
-          name: Install awscli
-          command: sudo pip install awscli
-      - run:
-          # CircleCI's AWS Credentials are allowed to assume a role that has S3
-          # access in the staging account.
-          name: Create an ~/.aws/config file to assume the staging role for aws.
-          command: mkdir -p ~/.aws && printf "[profile staging]\nrole_arn = ${AWS_STAGING_ROLE_ARN}\ncredential_source = Environment\n" > ~/.aws/config
-      - attach_workspace:
-          at: oasis-client
-      - run:
-          name: Deploy to S3
-          command: aws s3 sync --profile staging oasis-client/output/ s3://web3cjs-staging/oasis-client/ --delete
-
 
 workflows:
   version: 2
-  build-and-deploy:
+  build:
     jobs:
       - build
       - test-e2e
-      - deploy-staging:
-          requires:
-            - build
-          filters:
-            branches:
-              only: master
-      - deploy-release:
-          requires:
-            - build
-          filters:
-            branches:
-              only: master
-            tags:
-              only: /^@oasislabs*/


### PR DESCRIPTION
Builds are public on NPM. There's nothing that uses the hosted artifacts.