### PR TITLE
Increase verbosity of some errors

### DIFF
--- a/packages/confidential/src/ecdh-tweak.ts
+++ b/packages/confidential/src/ecdh-tweak.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/camelcase */
 import { sha512_256 } from 'js-sha512';
 
 import { PublicKey, PrivateKey } from '.';

--- a/packages/confidential/src/index.ts
+++ b/packages/confidential/src/index.ts
@@ -120,8 +120,13 @@ export function nonce(): Nonce {
 export function splitEncryptedPayload(
   encryption: Uint8Array
 ): [PublicKey, Uint8Array, Uint8Array, Nonce] {
-  if (encryption.length < ciphertextSize(0, 0)) {
-    throw new Error(`ciphertext is too short: ${encryption}`);
+  const minCiphertextSize = ciphertextSize(0, 0);
+  if (encryption.length < minCiphertextSize) {
+    throw new Error(
+      `Ciphertext is too short; it should have at least ${minCiphertextSize} bytes, but has ${
+        encryption.length
+      }: "${bytes.toHex(encryption)}"`
+    );
   }
   const nonce = new Uint8Array(aead.nonceSize());
   const publicKey = new Uint8Array(aead.keySize());

--- a/packages/gateway/src/index.ts
+++ b/packages/gateway/src/index.ts
@@ -275,7 +275,11 @@ class HttpGateway implements OasisGateway {
     const response = await this.session.request(api.method, api.url, body);
     const event = await this.polling.response(response.id);
     if ((event as ErrorEvent).cause) {
-      throw new Error(`poll error: ${JSON.stringify(event)}`);
+      throw new Error(
+        `Error when polling results from ${api.url} with ${JSON.stringify(
+          body
+        )}: ${JSON.stringify(event)}`
+      );
     }
     return event;
   }

--- a/packages/gateway/src/session.ts
+++ b/packages/gateway/src/session.ts
@@ -3,7 +3,7 @@ import { AxiosClient, HttpClient, HttpHeaders, Http } from './http';
 import * as _uuid from 'uuid';
 
 let uuid: any = undefined;
-let URL: any = undefined;
+let URL: any = undefined; // eslint-disable-line @typescript-eslint/no-unused-vars
 
 // Browser.
 if (typeof window !== 'undefined') {


### PR DESCRIPTION
The "ciphertext too short" comes up all the time. The other used to come up for me and I have had that change stored locally for a long time. Cannot hurt to add it.