### PR TITLE
Create LocalStorage equivalent in /tmp

### DIFF
--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@oasislabs/client",
-  "version": "1.0.0-rc.43",
+  "version": "1.0.0-rc.44",
   "description": "Client SDK for interacting with services on Oasis",
   "keywords": [
     "oasis",
@@ -49,10 +49,10 @@
     ]
   },
   "dependencies": {
-    "@oasislabs/common": "^1.0.0-rc.17",
-    "@oasislabs/gateway": "^1.0.0-rc.39",
-    "@oasislabs/service": "^1.0.0-rc.34",
-    "@oasislabs/web3": "^1.0.0-rc.23",
+    "@oasislabs/common": "^1.0.0-rc.18",
+    "@oasislabs/gateway": "^1.0.0-rc.40",
+    "@oasislabs/service": "^1.0.0-rc.35",
+    "@oasislabs/web3": "^1.0.0-rc.24",
     "find": "^0.3.0",
     "js-sha3": "^0.8.0",
     "toml": "^3.0.0"

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@oasislabs/common",
-  "version": "1.0.0-rc.17",
+  "version": "1.0.0-rc.18",
   "description": "Common utilities for Oasis packages",
   "keywords": [
     "oasis",

--- a/packages/common/src/db.ts
+++ b/packages/common/src/db.ts
@@ -9,7 +9,8 @@ export class LocalStorage implements Db {
   constructor() {
     // Node.
     if (typeof window === 'undefined') {
-      this.storage = require('node-localstorage').LocalStorage('.oasis');
+      const tmpDir = require('tmp').dirSync({ prefix: '.oasis-' }).name;
+      this.storage = require('node-localstorage').LocalStorage(tmpDir);
     }
     // Browser.
     else {

--- a/packages/confidential/package.json
+++ b/packages/confidential/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@oasislabs/confidential",
-  "version": "1.0.0-rc.23",
+  "version": "1.0.0-rc.24",
   "description": "Primitives for Confidential Services on Oasis",
   "keywords": [
     "oasis",
@@ -45,7 +45,7 @@
     ]
   },
   "dependencies": {
-    "@oasislabs/common": "^1.0.0-rc.17",
+    "@oasislabs/common": "^1.0.0-rc.18",
     "deoxysii": "^0.0.2",
     "js-sha512": "^0.8.0",
     "node-localstorage": "^2.1.4",

--- a/packages/gateway/package.json
+++ b/packages/gateway/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@oasislabs/gateway",
-  "version": "1.0.0-rc.39",
+  "version": "1.0.0-rc.40",
   "description": "Oasis Gateway implementation used as the client backend",
   "keywords": [
     "oasis",
@@ -45,8 +45,8 @@
     ]
   },
   "dependencies": {
-    "@oasislabs/common": "^1.0.0-rc.17",
-    "@oasislabs/service": "^1.0.0-rc.34",
+    "@oasislabs/common": "^1.0.0-rc.18",
+    "@oasislabs/service": "^1.0.0-rc.35",
     "@types/uuid": "^3.4.5",
     "axios": "^0.19.0",
     "pino": "^6.2.1",

--- a/packages/service/package.json
+++ b/packages/service/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@oasislabs/service",
-  "version": "1.0.0-rc.34",
+  "version": "1.0.0-rc.35",
   "description": "Connects to and deploys IDL defined services",
   "keywords": [
     "oasis",
@@ -45,8 +45,8 @@
     ]
   },
   "dependencies": {
-    "@oasislabs/common": "^1.0.0-rc.17",
-    "@oasislabs/confidential": "^1.0.0-rc.23",
+    "@oasislabs/common": "^1.0.0-rc.18",
+    "@oasislabs/confidential": "^1.0.0-rc.24",
     "@types/pako": "^1.0.1",
     "camelcase": "^5.3.1",
     "camelcase-keys": "^6.0.1",

--- a/packages/test/package.json
+++ b/packages/test/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@oasislabs/test",
-  "version": "1.0.0-rc.33",
+  "version": "1.0.0-rc.34",
   "description": "Tools used in Oasis tests",
   "repository": {
     "type": "git",
@@ -23,7 +23,7 @@
     "prepublishOnly": "yarn build"
   },
   "dependencies": {
-    "@oasislabs/common": "^1.0.0-rc.17",
-    "@oasislabs/service": "^1.0.0-rc.34"
+    "@oasislabs/common": "^1.0.0-rc.18",
+    "@oasislabs/service": "^1.0.0-rc.35"
   }
 }

--- a/packages/web3/package.json
+++ b/packages/web3/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@oasislabs/web3",
-  "version": "1.0.0-rc.23",
+  "version": "1.0.0-rc.24",
   "description": "Web3 JSON RPC compliant Oasis Gateway",
   "keywords": [
     "oasis",
@@ -45,9 +45,9 @@
     ]
   },
   "dependencies": {
-    "@oasislabs/common": "^1.0.0-rc.17",
-    "@oasislabs/service": "^1.0.0-rc.34",
-    "@oasislabs/test": "^1.0.0-rc.33",
+    "@oasislabs/common": "^1.0.0-rc.18",
+    "@oasislabs/service": "^1.0.0-rc.35",
+    "@oasislabs/test": "^1.0.0-rc.34",
     "axios": "^0.19.0",
     "ethers": "^4.0.27",
     "eventemitter3": "^4.0.0",


### PR DESCRIPTION
Resolves https://github.com/oasislabs/private-parcel/issues/786.

It should not be problematic to create LocalStorage in this new, less durable location, for two reasons: 1) Browser LocalStorage is also not guaranteed to be long-lasting, 2) The only uses that I can see are from gateway client and service.ts (which represents a WASM service), and neither of them need to retain state across machine reboots.

Testing:
```
nodejs
s = require('@oasislabs/common').LocalStorage
new s()
```
-- verified that it runs and that the location is in `/tmp`.