### PR TITLE
Extend polling timeout

### DIFF
--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@oasislabs/client",
-  "version": "1.0.0-rc.46",
+  "version": "1.0.0-rc.47",
   "description": "Client SDK for interacting with services on Oasis",
   "keywords": [
     "oasis",
@@ -50,7 +50,7 @@
   },
   "dependencies": {
     "@oasislabs/common": "^1.0.0-rc.19",
-    "@oasislabs/gateway": "^1.0.0-rc.42",
+    "@oasislabs/gateway": "^1.0.0-rc.43",
     "@oasislabs/service": "^1.0.0-rc.36",
     "@oasislabs/web3": "^1.0.0-rc.25",
     "find": "^0.3.0",

--- a/packages/gateway/package.json
+++ b/packages/gateway/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@oasislabs/gateway",
-  "version": "1.0.0-rc.42",
+  "version": "1.0.0-rc.43",
   "description": "Oasis Gateway implementation used as the client backend",
   "keywords": [
     "oasis",

--- a/packages/gateway/src/http.ts
+++ b/packages/gateway/src/http.ts
@@ -54,7 +54,7 @@ export class AxiosClient implements HttpClient {
    * Similar to `JSON.stringify()`, but clips long string values so they don't overwhelm the output.
    */
   private conciseDebugRepr(data: any): Record<string, any> {
-    let dataDigest: Record<string, any> = {}; // like `data`, but with long fields clipped
+    const dataDigest: Record<string, any> = {}; // like `data`, but with long fields clipped
     for (const key of Object.getOwnPropertyNames(data)) {
       const valStr = data[key]?.toString() || 'undefined';
       dataDigest[key] =
@@ -77,6 +77,7 @@ export class AxiosClient implements HttpClient {
     if (this.log?.isLevelEnabled('trace')) {
       this.log?.trace(
         {
+          // eslint-disable-next-line
           request_data: this.conciseDebugRepr(data),
           headers,
         },
@@ -92,6 +93,7 @@ export class AxiosClient implements HttpClient {
       .then(val => {
         if (this.log?.isLevelEnabled('trace')) {
           this.log?.trace(
+            // eslint-disable-next-line
             { http_response: this.conciseDebugRepr(val.data) },
             `Received HTTP response from ${url}`
           );

--- a/packages/gateway/src/polling.ts
+++ b/packages/gateway/src/polling.ts
@@ -47,8 +47,9 @@ export default class PollingService {
 
   /**
    * Amount of time (in ms) that can pass before being considered idle.
+   * The special value of 0 means "never consider it idle".
    */
-  private static IDLE_TIMELAPSE = 1000 * 3600 * 24 * 365; // 365 days
+  private static IDLE_TIMELAPSE = 0;
 
   /**
    * The constructor should never be invoked directly. To access the PollingService
@@ -146,9 +147,10 @@ export default class PollingService {
       id: this.queueId,
     });
 
-    // No responses so exit.
+    // If there have been no responses for longer than IDLE_TIMELAPSE, exit.
     if (
       responses.events.length === 0 &&
+      PollingService.IDLE_TIMELAPSE > 0 &&
       Date.now() - this.lastResponseTs >= PollingService.IDLE_TIMELAPSE
     ) {
       this.stop();

--- a/packages/gateway/src/polling.ts
+++ b/packages/gateway/src/polling.ts
@@ -46,9 +46,9 @@ export default class PollingService {
   private lastResponseTs: number;
 
   /**
-   * Amount of time that can pass before being considered idle.
+   * Amount of time (in ms) that can pass before being considered idle.
    */
-  private static IDLE_TIMELAPSE = 1000 * 60;
+  private static IDLE_TIMELAPSE = 1000 * 3600 * 24 * 365; // 365 days
 
   /**
    * The constructor should never be invoked directly. To access the PollingService

--- a/packages/gateway/src/polling.ts
+++ b/packages/gateway/src/polling.ts
@@ -39,19 +39,6 @@ export default class PollingService {
   private polling?: any;
 
   /**
-   * Millisecond timestamp representing the last time we received an event response
-   * from the gateway. When IDLE_TIMELAPSE milliseconds have passed, the
-   * PollingService is considered idle and stops.
-   */
-  private lastResponseTs: number;
-
-  /**
-   * Amount of time (in ms) that can pass before being considered idle.
-   * The special value of 0 means "never consider it idle".
-   */
-  private static IDLE_TIMELAPSE = 0;
-
-  /**
    * The constructor should never be invoked directly. To access the PollingService
    * use `PollingService.instance`.
    */
@@ -64,7 +51,6 @@ export default class PollingService {
     this.responseWindow = responseWindow ? responseWindow : new Window();
     this.interval = interval ? interval : 1000;
     this.responses = new EventEmitter();
-    this.lastResponseTs = Date.now();
   }
 
   /**
@@ -147,18 +133,7 @@ export default class PollingService {
       id: this.queueId,
     });
 
-    // If there have been no responses for longer than IDLE_TIMELAPSE, exit.
-    if (
-      responses.events.length === 0 &&
-      PollingService.IDLE_TIMELAPSE > 0 &&
-      Date.now() - this.lastResponseTs >= PollingService.IDLE_TIMELAPSE
-    ) {
-      this.stop();
-      return;
-    }
-
     responses.events.forEach((r: any) => {
-      this.lastResponseTs = Date.now();
       this.responses.emit(this.topic(r), r);
       this.responseWindow.slide(r.id, r);
       if (this.responseWindow.isClosed()) {


### PR DESCRIPTION
PR #342 had an unexpected side effect where `IDLE_TIMELAPSE` started being heeded correctly. So all event polling ran for at most 60s. This is way too little for the offchain worker (that needs to wait possibly for days between jobs), and even for the offchain compute client (that needs to wait for the job to complete).

This PR extends the timeout to the point where it is practically disabled, but given that that is how we operated this whole time, the change should be non-controversial.

Should we do the same in Go?

More context: https://github.com/oasislabs/private-parcel/issues/842